### PR TITLE
Make cluster aggregator node into a cost-model-dependent EC

### DIFF
--- a/src/engine/coordinator.cc
+++ b/src/engine/coordinator.cc
@@ -71,7 +71,7 @@ Coordinator::Coordinator(PlatformID platform_id)
   string desc_name = "Coordinator on " + hostname_;
   resource_desc_.set_uuid(to_string(uuid_));
   resource_desc_.set_friendly_name(desc_name);
-  resource_desc_.set_type(ResourceDescriptor::RESOURCE_MACHINE);
+  resource_desc_.set_type(ResourceDescriptor::RESOURCE_COORDINATOR);
   //resource_desc_.set_storage_engine(object_store_->get_listening_interface());
   local_resource_topology_->mutable_resource_desc()->CopyFrom(
       resource_desc_);

--- a/src/engine/node.cc
+++ b/src/engine/node.cc
@@ -38,7 +38,6 @@ Node::Node(PlatformID platform_id, ResourceID_t uuid)
     uuid_(uuid) {
   // Set up the node's resource descriptor
   resource_desc_.set_uuid(to_string(uuid_));
-  resource_desc_.set_type(ResourceDescriptor::RESOURCE_MACHINE);
 
   switch (platform_id) {
     case PL_UNIX: {

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -203,6 +203,12 @@ size_t HashJobID(const TaskDescriptor& td) {
   return hash;
 }
 
+size_t HashString(const string& str) {
+  size_t hash = 42;
+  boost::hash_combine(hash, str);
+  return hash;
+}
+
 DataObjectID_t DataObjectIDFromString(const string& str) {
   // N.B.: This assumes that the string is a readable, hexadecimal
   // representation of the ID.

--- a/src/misc/utils.h
+++ b/src/misc/utils.h
@@ -58,6 +58,7 @@ TaskID_t GenerateTaskID(const TaskDescriptor& parent_task);
 TaskID_t GenerateTaskID(const TaskDescriptor& parent_task, uint64_t child_num);
 size_t HashJobID(JobID_t job_id);
 size_t HashJobID(const TaskDescriptor& td);
+size_t HashString(const string& str);
 // Utility functions to parse various types from strings.
 DataObjectID_t DataObjectIDFromString(const string& str);
 DataObjectID_t DataObjectIDFromProtobuf(const string& str);

--- a/src/scheduling/flow/coco_cost_model.h
+++ b/src/scheduling/flow/coco_cost_model.h
@@ -50,7 +50,6 @@ class CocoCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -84,7 +83,10 @@ class CocoCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // Helper method to get TD for a task ID
   const TaskDescriptor& GetTask(TaskID_t task_id);
+  // Cost to cluster aggregator EC
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   // Fixed value for OMEGA, the normalization ceiling for each dimension's cost
   // value
   const uint64_t omega_ = 1000;

--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -52,12 +52,6 @@ class CostModelInterface {
   virtual Cost_t UnscheduledAggToSinkCost(JobID_t job_id) = 0;
 
   /**
-   * Get the cost of an arc from a task node to the cluster
-   * aggregator node.
-   */
-  virtual Cost_t TaskToClusterAggCost(TaskID_t task_id) = 0;
-
-  /**
    * Get the cost of a preference arc from a task node to a resource node.
    */
   virtual Cost_t TaskToResourceNodeCost(TaskID_t task_id,

--- a/src/scheduling/flow/flow_graph.h
+++ b/src/scheduling/flow/flow_graph.h
@@ -74,11 +74,8 @@ class FlowGraph {
   inline const unordered_set<uint64_t>& unsched_agg_ids() const {
     return unsched_agg_nodes_;
   }
-  inline const FlowGraphNode& cluster_agg_node() const {
-    return *cluster_agg_node_;
-  }
   inline uint64_t NumArcs() const { return arc_set_.size(); }
-  inline uint64_t NumNodes() const { return current_id_ - 1; }
+  inline uint64_t NumNodes() const { return node_map_.size(); }
   inline FlowGraphNode* Node(uint64_t id) {
     FlowGraphNode* const* npp = FindOrNull(node_map_, id);
     return (npp ? *npp : NULL);
@@ -99,6 +96,8 @@ class FlowGraph {
   FRIEND_TEST(FlowGraphTest, DeleteResourceNode);
   FRIEND_TEST(FlowGraphTest, ResetChanges);
   FRIEND_TEST(FlowGraphTest, UnschedAggCapacityAdjustment);
+  FRIEND_TEST(FlowGraphTest, DeleteReAddResourceTopo);
+  FRIEND_TEST(FlowGraphTest, DeleteReAddResourceTopoAndJob);
   void AddArcsForTask(FlowGraphNode* task_node, FlowGraphNode* unsched_agg_node,
                       vector<FlowGraphArc*>* task_arcs);
   FlowGraphArc* AddArcInternal(FlowGraphNode* src, FlowGraphNode* dst);
@@ -113,8 +112,7 @@ class FlowGraph {
   void AddTaskEquivClasses(FlowGraphNode* task_node);
   void AdjustUnscheduledAggToSinkCapacityGeneratingDelta(
       JobID_t job, int64_t delta);
-  void ConfigureResourceRootNode(const ResourceTopologyNodeDescriptor& rtnd,
-                                 FlowGraphNode* new_node);
+  void ConfigureResourceNodeECs(ResourceTopologyNodeDescriptor* rtnd);
   void ConfigureResourceBranchNode(const ResourceTopologyNodeDescriptor& rtnd,
                                    FlowGraphNode* new_node);
   void ConfigureResourceLeafNode(const ResourceTopologyNodeDescriptor& rtnd,
@@ -145,7 +143,6 @@ class FlowGraph {
   uint64_t current_id_;
   unordered_map<uint64_t, FlowGraphNode*> node_map_;
   unordered_set<FlowGraphArc*> arc_set_;
-  FlowGraphNode* cluster_agg_node_;
   FlowGraphNode* sink_node_;
   // Resource and task mappings
   unordered_map<TaskID_t, uint64_t> task_to_nodeid_map_;

--- a/src/scheduling/flow/flow_scheduler.cc
+++ b/src/scheduling/flow/flow_scheduler.cc
@@ -92,7 +92,7 @@ FlowScheduler::FlowScheduler(
       VLOG(1) << "Using the Whare-Map cost model";
       break;
     case CostModelType::COST_MODEL_OCTOPUS:
-      cost_model_ = new OctopusCostModel(resource_map);
+      cost_model_ = new OctopusCostModel(resource_map, task_map);
       VLOG(1) << "Using the octopus cost model";
       break;
     default:

--- a/src/scheduling/flow/octopus_cost_model.cc
+++ b/src/scheduling/flow/octopus_cost_model.cc
@@ -6,14 +6,20 @@
 #include <utility>
 #include <vector>
 
+#include "misc/utils.h"
 #include "misc/map-util.h"
 #include "scheduling/flow/dimacs_change_arc.h"
 #include "scheduling/flow/flow_graph.h"
 
 namespace firmament {
 
-OctopusCostModel::OctopusCostModel(shared_ptr<ResourceMap_t> resource_map)
-  : resource_map_(resource_map) {
+OctopusCostModel::OctopusCostModel(shared_ptr<ResourceMap_t> resource_map,
+                                   shared_ptr<TaskMap_t> task_map)
+  : resource_map_(resource_map),
+    task_map_(task_map) {
+  // Create the cluster aggregator EC, which all machines are members of.
+  cluster_aggregator_ec_ = HashString("CLUSTER_AGG");
+  VLOG(1) << "Cluster aggregator EC is " << cluster_aggregator_ec_;
 }
 
 Cost_t OctopusCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
@@ -38,8 +44,10 @@ Cost_t OctopusCostModel::ResourceNodeToResourceNodeCost(
   ResourceStatus* dst_rs_ptr = FindPtrOrNull(*resource_map_, dst);
   CHECK_NOTNULL(dst_rs_ptr);
   ResourceDescriptor* dst_rd_ptr = dst_rs_ptr->mutable_descriptor();
-
-  return dst_rd_ptr->num_running_tasks();
+  // The cost in the Octopus model is the number of already running tasks, i.e.
+  // a crude per-task load balancing algorithm.
+  uint64_t num_tasks = dst_rd_ptr->num_running_tasks();
+  return num_tasks;
 }
 
 Cost_t OctopusCostModel::LeafResourceNodeToSinkCost(ResourceID_t resource_id) {
@@ -55,71 +63,104 @@ Cost_t OctopusCostModel::TaskPreemptionCost(TaskID_t task_id) {
 }
 
 Cost_t OctopusCostModel::TaskToEquivClassAggregator(TaskID_t task_id,
-                                                    EquivClass_t tec) {
+                                                    EquivClass_t ec) {
   return 0ULL;
 }
 
-Cost_t OctopusCostModel::EquivClassToResourceNode(EquivClass_t tec,
+Cost_t OctopusCostModel::EquivClassToResourceNode(EquivClass_t ec,
                                                   ResourceID_t res_id) {
   return 0ULL;
 }
 
-Cost_t OctopusCostModel::EquivClassToEquivClass(EquivClass_t tec1,
-                                                EquivClass_t tec2) {
+Cost_t OctopusCostModel::EquivClassToEquivClass(EquivClass_t ec1,
+                                                EquivClass_t ec2) {
   return 0LL;
 }
 
 vector<EquivClass_t>* OctopusCostModel::GetTaskEquivClasses(
     TaskID_t task_id) {
   vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
-  // TaskDescriptor* td_ptr = FindPtrOrNull(*task_map_, task_id);
-  // CHECK_NOTNULL(td_ptr);
-  // // A level 0 TEC is the hash of the task binary name.
-  // size_t hash = 0;
-  // boost::hash_combine(hash, td_ptr->binary());
-  // equiv_classes->push_back(static_cast<EquivClass_t>(hash));
+  // All tasks have an arc to the cluster aggregator, i.e. they are
+  // all in the cluster aggregator EC.
+  equiv_classes->push_back(cluster_aggregator_ec_);
   return equiv_classes;
 }
 
 vector<EquivClass_t>* OctopusCostModel::GetResourceEquivClasses(
     ResourceID_t res_id) {
   vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
+  // Only the cluster aggregator for the Octopus cost model
+  equiv_classes->push_back(cluster_aggregator_ec_);
   return equiv_classes;
 }
 
 vector<ResourceID_t>* OctopusCostModel::GetOutgoingEquivClassPrefArcs(
-    EquivClass_t tec) {
-  vector<ResourceID_t>* prefered_res = new vector<ResourceID_t>();
-  return prefered_res;
+    EquivClass_t ec) {
+  vector<ResourceID_t>* arc_destinations = new vector<ResourceID_t>();
+  if (ec == cluster_aggregator_ec_) {
+    // ec is the cluster aggregator, and has arcs to all machines.
+    // XXX(malte): This is inefficient, as it needlessly adds all the
+    // machines every time we call this. To optimize, we can just include
+    // the ones for which arcs are missing.
+    for (auto it = machines_.begin();
+         it != machines_.end();
+         ++it) {
+      arc_destinations->push_back(*it);
+    }
+  }
+  return arc_destinations;
 }
 
 vector<TaskID_t>* OctopusCostModel::GetIncomingEquivClassPrefArcs(
-    EquivClass_t tec) {
-  vector<TaskID_t>* prefered_tasks = new vector<TaskID_t>();
-  return prefered_tasks;
+    EquivClass_t ec) {
+  vector<TaskID_t>* tasks_with_incoming_arcs = new vector<TaskID_t>();
+  if (ec == cluster_aggregator_ec_) {
+    // ec is the cluster aggregator.
+    // We add an arc from each task to the cluster aggregator.
+    // XXX(malte): This is very slow because it iterates over all tasks; we
+    // should instead only return the set of tasks that do not yet have the
+    // appropriate arcs.
+    for (TaskMap_t::iterator it = task_map_->begin(); it != task_map_->end();
+         ++it) {
+      // XXX(malte): task_map_ contains ALL tasks ever seen by the system,
+      // including those that have completed, failed or are otherwise no longer
+      // present in the flow graph. We do some crude filtering here, but clearly
+      // we should instead maintain a collection of tasks actually eligible for
+      // scheduling.
+      if (it->second->state() == TaskDescriptor::RUNNABLE ||
+          it->second->state() == TaskDescriptor::RUNNING)
+        tasks_with_incoming_arcs->push_back(it->first);
+    }
+  }
+  return tasks_with_incoming_arcs;
 }
 
 vector<ResourceID_t>* OctopusCostModel::GetTaskPreferenceArcs(
     TaskID_t task_id) {
-  vector<ResourceID_t>* prefered_res = new vector<ResourceID_t>();
-  return prefered_res;
+  // Not used in Octopus cost model
+  return NULL;
 }
 
 pair<vector<EquivClass_t>*, vector<EquivClass_t>*>
-    OctopusCostModel::GetEquivClassToEquivClassesArcs(EquivClass_t tec) {
-  vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
+    OctopusCostModel::GetEquivClassToEquivClassesArcs(EquivClass_t ec) {
   return pair<vector<EquivClass_t>*,
-              vector<EquivClass_t>*>(equiv_classes, equiv_classes);
+              vector<EquivClass_t>*>(NULL, NULL);
 }
 
 void OctopusCostModel::AddMachine(
     ResourceTopologyNodeDescriptor* rtnd_ptr) {
+  CHECK_NOTNULL(rtnd_ptr);
+  // Keep track of the new machine
+  CHECK(rtnd_ptr->resource_desc().type() == 
+      ResourceDescriptor::RESOURCE_MACHINE);
+  machines_.insert(ResourceIDFromString(rtnd_ptr->resource_desc().uuid()));
 }
 
 void OctopusCostModel::AddTask(TaskID_t task_id) {
 }
 
 void OctopusCostModel::RemoveMachine(ResourceID_t res_id) {
+  CHECK_EQ(machines_.erase(res_id), 1);
 }
 
 void OctopusCostModel::RemoveTask(TaskID_t task_id) {

--- a/src/scheduling/flow/octopus_cost_model.cc
+++ b/src/scheduling/flow/octopus_cost_model.cc
@@ -151,7 +151,7 @@ void OctopusCostModel::AddMachine(
     ResourceTopologyNodeDescriptor* rtnd_ptr) {
   CHECK_NOTNULL(rtnd_ptr);
   // Keep track of the new machine
-  CHECK(rtnd_ptr->resource_desc().type() == 
+  CHECK(rtnd_ptr->resource_desc().type() ==
       ResourceDescriptor::RESOURCE_MACHINE);
   machines_.insert(ResourceIDFromString(rtnd_ptr->resource_desc().uuid()));
 }

--- a/src/scheduling/flow/octopus_cost_model.h
+++ b/src/scheduling/flow/octopus_cost_model.h
@@ -16,7 +16,8 @@ namespace firmament {
 
 class OctopusCostModel : public CostModelInterface {
  public:
-  explicit OctopusCostModel(shared_ptr<ResourceMap_t> resource_map);
+  explicit OctopusCostModel(shared_ptr<ResourceMap_t> resource_map,
+                            shared_ptr<TaskMap_t> task_map);
   // Costs pertaining to leaving tasks unscheduled
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
@@ -51,7 +52,14 @@ class OctopusCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // EC corresponding to the CLUSTER_AGG node
+  EquivClass_t cluster_aggregator_ec_;
+  // Set of node IDs corresponding to machines
+  unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>> machines_;
+  // The resource map used in the rest of the system
   shared_ptr<ResourceMap_t> resource_map_;
+  // The task map used in the rest of the system
+  shared_ptr<TaskMap_t> task_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/octopus_cost_model.h
+++ b/src/scheduling/flow/octopus_cost_model.h
@@ -22,7 +22,6 @@ class OctopusCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -52,6 +51,9 @@ class OctopusCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // Cost to cluster aggregator EC
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
+
   // EC corresponding to the CLUSTER_AGG node
   EquivClass_t cluster_aggregator_ec_;
   // Set of node IDs corresponding to machines

--- a/src/scheduling/flow/quincy_cost_model.h
+++ b/src/scheduling/flow/quincy_cost_model.h
@@ -36,7 +36,6 @@ class QuincyCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -66,6 +65,9 @@ class QuincyCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // Cost to cluster aggregator EC
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
+
   // Lookup maps for various resources from the scheduler.
   shared_ptr<ResourceMap_t> resource_map_;
   // Information regarding jobs and tasks.

--- a/src/scheduling/flow/random_cost_model.cc
+++ b/src/scheduling/flow/random_cost_model.cc
@@ -63,9 +63,10 @@ Cost_t RandomCostModel::TaskPreemptionCost(TaskID_t task_id) {
 
 Cost_t RandomCostModel::TaskToEquivClassAggregator(TaskID_t task_id,
                                                    EquivClass_t ec) {
-  // The cost of scheduling via the cluster aggregator
+  // The cost of scheduling via the cluster aggregator; always slightly
+  // less than the cost of leaving the task unscheduled
   if (ec == cluster_aggregator_ec_)
-    return TaskToUnscheduledAggCost(task_id);
+    return rand() % TaskToUnscheduledAggCost(task_id) - 1;
   else
     // XXX(malte): Implement other EC's costs!
     return 0;
@@ -201,7 +202,7 @@ void RandomCostModel::AddMachine(
     ResourceTopologyNodeDescriptor* rtnd_ptr) {
   CHECK_NOTNULL(rtnd_ptr);
   // Keep track of the new machine
-  CHECK(rtnd_ptr->resource_desc().type() == 
+  CHECK(rtnd_ptr->resource_desc().type() ==
       ResourceDescriptor::RESOURCE_MACHINE);
   machines_.insert(ResourceIDFromString(rtnd_ptr->resource_desc().uuid()));
 }

--- a/src/scheduling/flow/random_cost_model.h
+++ b/src/scheduling/flow/random_cost_model.h
@@ -25,7 +25,6 @@ class RandomCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -55,9 +54,20 @@ class RandomCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // EC corresponding to the CLUSTER_AGG node
+  EquivClass_t cluster_aggregator_ec_;
+  // Set of node IDs corresponding to machines
+  unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>> machines_;
+  // Set of task ECs
+  unordered_set<EquivClass_t> task_aggs_;
+  // Mapping between task equiv classes and connected tasks.
+  unordered_map<EquivClass_t, set<TaskID_t> > task_ec_to_set_task_id_;
+  // The task map used in the rest of the system
   shared_ptr<TaskMap_t> task_map_;
+  // Leaf resource's resource IDs
   unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>>* leaf_res_ids_;
-  uint32_t rand_seed_ = 0;
+  // A seed for the RNG
+  uint32_t rand_seed_ = 1234;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/simulated_quincy_cost_model.h
+++ b/src/scheduling/flow/simulated_quincy_cost_model.h
@@ -53,7 +53,6 @@ class SimulatedQuincyCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -85,6 +84,7 @@ class SimulatedQuincyCostModel : public CostModelInterface {
  private:
   void BuildTaskFileSet(TaskID_t task_id);
   void ComputeCostsAndPreferredSet(TaskID_t task_id);
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
 
   // Lookup maps for various resources from the scheduler.
   shared_ptr<ResourceMap_t> resource_map_;

--- a/src/scheduling/flow/sjf_cost_model.h
+++ b/src/scheduling/flow/sjf_cost_model.h
@@ -29,7 +29,6 @@ class SJFCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -59,6 +58,9 @@ class SJFCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  // Cost to cluster aggregator EC
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
+
   const Cost_t WAIT_TIME_MULTIPLIER = 1;
 
   const TaskDescriptor& GetTask(TaskID_t task_id);

--- a/src/scheduling/flow/trivial_cost_model.cc
+++ b/src/scheduling/flow/trivial_cost_model.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "misc/map-util.h"
+#include "misc/utils.h"
 
 namespace firmament {
 
@@ -16,7 +17,11 @@ TrivialCostModel::TrivialCostModel(
     shared_ptr<TaskMap_t> task_map,
     unordered_set<ResourceID_t,
       boost::hash<boost::uuids::uuid>>* leaf_res_ids)
-  : task_map_(task_map), leaf_res_ids_(leaf_res_ids) {
+  : leaf_res_ids_(leaf_res_ids),
+    task_map_(task_map) {
+  // Create the cluster aggregator EC, which all machines are members of.
+  cluster_aggregator_ec_ = HashString("CLUSTER_AGG");
+  VLOG(1) << "Cluster aggregator EC is " << cluster_aggregator_ec_;
 }
 
 Cost_t TrivialCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
@@ -25,10 +30,6 @@ Cost_t TrivialCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
 
 Cost_t TrivialCostModel::UnscheduledAggToSinkCost(JobID_t job_id) {
   return 0LL;
-}
-
-Cost_t TrivialCostModel::TaskToClusterAggCost(TaskID_t task_id) {
-  return 2LL;
 }
 
 Cost_t TrivialCostModel::TaskToResourceNodeCost(TaskID_t task_id,
@@ -55,8 +56,11 @@ Cost_t TrivialCostModel::TaskPreemptionCost(TaskID_t task_id) {
 }
 
 Cost_t TrivialCostModel::TaskToEquivClassAggregator(TaskID_t task_id,
-                                                    EquivClass_t tec) {
-  return 0ULL;
+                                                    EquivClass_t ec) {
+  if (ec == cluster_aggregator_ec_)
+    return 2ULL;
+  else
+    return 0ULL;
 }
 
 Cost_t TrivialCostModel::EquivClassToResourceNode(EquivClass_t tec,
@@ -78,17 +82,62 @@ vector<EquivClass_t>* TrivialCostModel::GetTaskEquivClasses(
   size_t hash = 0;
   boost::hash_combine(hash, td_ptr->binary());
   equiv_classes->push_back(static_cast<EquivClass_t>(hash));
+  // All tasks also have an arc to the cluster aggregator.
+  equiv_classes->push_back(cluster_aggregator_ec_);
   return equiv_classes;
 }
 
 vector<EquivClass_t>* TrivialCostModel::GetResourceEquivClasses(
     ResourceID_t res_id) {
-  LOG(FATAL) << "Not implemented";
-  return NULL;
+  vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
+  // Only the cluster aggregator for the trivial cost model
+  equiv_classes->push_back(cluster_aggregator_ec_);
+  return equiv_classes;
 }
 
 vector<ResourceID_t>* TrivialCostModel::GetOutgoingEquivClassPrefArcs(
-    EquivClass_t tec) {
+    EquivClass_t ec) {
+  vector<ResourceID_t>* prefered_res = new vector<ResourceID_t>();
+  if (ec == cluster_aggregator_ec_) {
+    // ec is the cluster aggregator, and has arcs to all machines.
+    // XXX(malte): This is inefficient, as it needlessly adds all the
+    // machines every time we call this. To optimize, we can just include
+    // the ones for which arcs are missing.
+    for (auto it = machine_to_rtnd_.begin();
+         it != machine_to_rtnd_.end();
+         ++it) {
+      prefered_res->push_back(it->first);
+    }
+  }
+  return prefered_res;
+}
+
+vector<TaskID_t>* TrivialCostModel::GetIncomingEquivClassPrefArcs(
+    EquivClass_t ec) {
+  vector<TaskID_t>* tasks_with_incoming_arcs = new vector<TaskID_t>();
+  if (ec == cluster_aggregator_ec_) {
+    // ec is the cluster aggregator.
+    // We add an arc from each task to the cluster aggregator.
+    // XXX(malte): This is very slow because it iterates over all tasks; we
+    // should instead only return the set of tasks that do not yet have the
+    // appropriate arcs.
+    for (TaskMap_t::iterator it = task_map_->begin(); it != task_map_->end();
+         ++it) {
+      // XXX(malte): task_map_ contains ALL tasks ever seen by the system,
+      // including those that have completed, failed or are otherwise no longer
+      // present in the flow graph. We do some crude filtering here, but clearly
+      // we should instead maintain a collection of tasks actually eligible for
+      // scheduling.
+      if (it->second->state() == TaskDescriptor::RUNNABLE ||
+          it->second->state() == TaskDescriptor::RUNNING)
+        tasks_with_incoming_arcs->push_back(it->first);
+    }
+  }
+  return tasks_with_incoming_arcs;
+}
+
+vector<ResourceID_t>* TrivialCostModel::GetTaskPreferenceArcs(
+    TaskID_t task_id) {
   vector<ResourceID_t>* prefered_res = new vector<ResourceID_t>();
   CHECK_GE(leaf_res_ids_->size(), FLAGS_num_pref_arcs_task_to_res);
   uint32_t rand_seed_ = 0;
@@ -103,33 +152,27 @@ vector<ResourceID_t>* TrivialCostModel::GetOutgoingEquivClassPrefArcs(
   return prefered_res;
 }
 
-vector<TaskID_t>* TrivialCostModel::GetIncomingEquivClassPrefArcs(
-    EquivClass_t tec) {
-  LOG(FATAL) << "Not implemented!";
-  return NULL;
-}
-
-vector<ResourceID_t>* TrivialCostModel::GetTaskPreferenceArcs(
-    TaskID_t task_id) {
-  vector<ResourceID_t>* prefered_res = new vector<ResourceID_t>();
-  return prefered_res;
-}
-
 pair<vector<EquivClass_t>*, vector<EquivClass_t>*>
     TrivialCostModel::GetEquivClassToEquivClassesArcs(EquivClass_t tec) {
-  vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
-  return pair<vector<EquivClass_t>*,
-              vector<EquivClass_t>*>(equiv_classes, equiv_classes);
+  // The trivial cost model does not have any interconnected ECs.
+  return pair<vector<EquivClass_t>*, vector<EquivClass_t>*>(NULL, NULL);
 }
 
 void TrivialCostModel::AddMachine(
     ResourceTopologyNodeDescriptor* rtnd_ptr) {
+  CHECK_EQ(rtnd_ptr->resource_desc().type(),
+           ResourceDescriptor::RESOURCE_MACHINE);
+  // Add mapping between resource id and resource topology node.
+  InsertIfNotPresent(&machine_to_rtnd_,
+                     ResourceIDFromString(rtnd_ptr->resource_desc().uuid()),
+                     rtnd_ptr);
 }
 
 void TrivialCostModel::AddTask(TaskID_t task_id) {
 }
 
 void TrivialCostModel::RemoveMachine(ResourceID_t res_id) {
+  CHECK_EQ(machine_to_rtnd_.erase(res_id), 1);
 }
 
 void TrivialCostModel::RemoveTask(TaskID_t task_id) {

--- a/src/scheduling/flow/trivial_cost_model.h
+++ b/src/scheduling/flow/trivial_cost_model.h
@@ -27,7 +27,6 @@ class TrivialCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -58,8 +57,13 @@ class TrivialCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
-  shared_ptr<TaskMap_t> task_map_;
+  // EC corresponding to the CLUSTER_AGG node
+  EquivClass_t cluster_aggregator_ec_;
   unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>>* leaf_res_ids_;
+  // Mapping betweeen machine res id and resource topology node descriptor.
+  unordered_map<ResourceID_t, const ResourceTopologyNodeDescriptor*,
+    boost::hash<boost::uuids::uuid>> machine_to_rtnd_;
+  shared_ptr<TaskMap_t> task_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/void_cost_model.h
+++ b/src/scheduling/flow/void_cost_model.h
@@ -22,7 +22,6 @@ class VoidCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -51,6 +50,9 @@ class VoidCostModel : public CostModelInterface {
   void RemoveTask(TaskID_t task_id);
   FlowGraphNode* GatherStats(FlowGraphNode* accumulator, FlowGraphNode* other);
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
+
+ private:
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -67,8 +67,16 @@ class WhareMapCostModel : public CostModelInterface {
   void ComputeMachineTypeHash(const ResourceTopologyNodeDescriptor* rtnd_ptr,
                               size_t* hash);
 
+  // Map of resources present in the system, initialised externally
   shared_ptr<ResourceMap_t> resource_map_;
+  // Map of tasks present in the system, initialised externally
   shared_ptr<TaskMap_t> task_map_;
+  // A knowledge base instance that we refer to for job runtime statistics,
+  // initialised externally
+  KnowledgeBase* knowledge_base_;
+
+  // EC corresponding to the CLUSTER_AGG node
+  EquivClass_t cluster_aggregator_ec_;
   // Mapping between machine equiv classes and machines.
   multimap<EquivClass_t, ResourceID_t> machine_ec_to_res_id_;
   // Mapping betweeen machine res id and resource topology node descriptor.
@@ -77,14 +85,12 @@ class WhareMapCostModel : public CostModelInterface {
   // Mapping between machine res id and task equiv class.
   unordered_map<ResourceID_t, EquivClass_t,
     boost::hash<boost::uuids::uuid>> machine_to_ec_;
-
   // Mapping between task equiv classes and connected tasks.
   unordered_map<EquivClass_t, set<TaskID_t> > task_ec_to_set_task_id_;
-
+  // Set of task ECs
   unordered_set<EquivClass_t> task_aggs_;
+  // Set of machine ECs
   unordered_set<EquivClass_t> machine_aggs_;
-  // A knowledge base instance that we will refer to for job runtime statistics.
-  KnowledgeBase* knowledge_base_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -31,7 +31,6 @@ class WhareMapCostModel : public CostModelInterface {
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
   // Per-task costs (into the resource topology)
-  Cost_t TaskToClusterAggCost(TaskID_t task_id);
   Cost_t TaskToResourceNodeCost(TaskID_t task_id,
                                 ResourceID_t resource_id);
   // Costs within the resource topology
@@ -66,6 +65,8 @@ class WhareMapCostModel : public CostModelInterface {
   const TaskDescriptor& GetTask(TaskID_t task_id);
   void ComputeMachineTypeHash(const ResourceTopologyNodeDescriptor* rtnd_ptr,
                               size_t* hash);
+  // Cost to cluster aggregator EC
+  Cost_t TaskToClusterAggCost(TaskID_t task_id);
 
   // Map of resources present in the system, initialised externally
   shared_ptr<ResourceMap_t> resource_map_;

--- a/src/sim/trace-extract/google_trace_simulator.cc
+++ b/src/sim/trace-extract/google_trace_simulator.cc
@@ -167,7 +167,7 @@ GoogleTraceSimulator::GoogleTraceSimulator(const string& trace_path) :
     VLOG(1) << "Using the Whare-Map cost model";
     break;
   case CostModelType::COST_MODEL_OCTOPUS:
-    cost_model_ = new OctopusCostModel(resource_map_);
+    cost_model_ = new OctopusCostModel(resource_map_, task_map_);
     VLOG(1) << "Using the octopus cost model";
     break;
   case CostModelType::COST_MODEL_VOID:


### PR DESCRIPTION
This PR amends our notion of the cluster aggregator ("don't care"/"X") node in the flow graph. Since some of the cost models we use do not have a cluster aggregator node, it seems prudent not to hard-code its existence into the flow graph code.

Instead, cost models can now themselves create a cluster aggregator node by simply producing an equivalence class of which all tasks and all machines (or racks, or cores, or resources in general) are members. This PR also updates the majority of cost models to work with this new notion (done: trivial, random, WhareMap and Octopus cost models; to do: SJF, Quincy, CoCo and simulated Quincy).

I will keep updating this PR over the next few days, but I'm pushing it out already so that review of the (substantial) changes can begin.