### PR TITLE
Update the SJF cost model to use the new EC-based cluster aggregator scheme

### DIFF
--- a/src/scheduling/flow/sjf_cost_model.h
+++ b/src/scheduling/flow/sjf_cost_model.h
@@ -58,17 +58,21 @@ class SJFCostModel : public CostModelInterface {
   FlowGraphNode* UpdateStats(FlowGraphNode* accumulator, FlowGraphNode* other);
 
  private:
+  const TaskDescriptor& GetTask(TaskID_t task_id);
   // Cost to cluster aggregator EC
   Cost_t TaskToClusterAggCost(TaskID_t task_id);
 
   const Cost_t WAIT_TIME_MULTIPLIER = 1;
 
-  const TaskDescriptor& GetTask(TaskID_t task_id);
-
-  shared_ptr<TaskMap_t> task_map_;
-  unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>>* leaf_res_ids_;
+  // EC corresponding to the CLUSTER_AGG node
+  EquivClass_t cluster_aggregator_ec_;
   // A knowledge base instance that we will refer to for job runtime statistics.
   KnowledgeBase* knowledge_base_;
+  // Mapping betweeen machine res id and resource topology node descriptor.
+  unordered_map<ResourceID_t, const ResourceTopologyNodeDescriptor*,
+    boost::hash<boost::uuids::uuid>> machine_to_rtnd_;
+  // Shared access to the overall set of tasks
+  shared_ptr<TaskMap_t> task_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/trivial_cost_model.h
+++ b/src/scheduling/flow/trivial_cost_model.h
@@ -63,6 +63,7 @@ class TrivialCostModel : public CostModelInterface {
   // Mapping betweeen machine res id and resource topology node descriptor.
   unordered_map<ResourceID_t, const ResourceTopologyNodeDescriptor*,
     boost::hash<boost::uuids::uuid>> machine_to_rtnd_;
+  // Shared access to the overall set of tasks
   shared_ptr<TaskMap_t> task_map_;
 };
 


### PR DESCRIPTION
The SJF cost model now creates its own cluster aggregator node and and connects it appropriately. Also added an illustrative comment to the trivial cost model header.