### PR TITLE
Introduce regular updates of time-dependent costs in flow scheduler.

### DIFF
--- a/src/scheduling/flow/flow_graph.cc
+++ b/src/scheduling/flow/flow_graph.cc
@@ -1194,6 +1194,15 @@ void FlowGraph::ResetChanges() {
   ids_created_.clear();
 }
 
+void FlowGraph::UpdateTimeDependentCosts(vector<JobDescriptor*>* jobs) {
+  for (auto it = jobs->begin();
+       it != jobs->end();
+       ++it) {
+    VLOG(1) << "Reconsidering time-dependent costs for job " << (*it)->uuid();
+    AddOrUpdateJobNodes(*it);
+  }
+}
+
 void FlowGraph::ComputeTopologyStatistics(
     FlowGraphNode* node,
     boost::function<FlowGraphNode*(FlowGraphNode*, FlowGraphNode*)> gather) {

--- a/src/scheduling/flow/flow_graph.h
+++ b/src/scheduling/flow/flow_graph.h
@@ -60,6 +60,7 @@ class FlowGraph {
     boost::function<FlowGraphNode*(FlowGraphNode*, FlowGraphNode*)> gather);
   void UpdateResourceTopology(
       ResourceTopologyNodeDescriptor* resource_tree);
+  void UpdateTimeDependentCosts(vector<JobDescriptor*>* job_vec);
   // Simple accessor methods
   inline const unordered_set<FlowGraphArc*>& Arcs() const { return arc_set_; }
   inline const unordered_map<uint64_t, FlowGraphNode*>& Nodes() const {

--- a/src/scheduling/flow/flow_scheduler.cc
+++ b/src/scheduling/flow/flow_scheduler.cc
@@ -29,6 +29,8 @@ DEFINE_int32(flow_scheduling_cost_model, 0,
              "Flow scheduler cost model to use. "
              "Values: 0 = TRIVIAL, 1 = RANDOM, 2 = SJF, 3 = QUINCY, "
              "4 = WHARE, 5 = COCO, 6 = OCTOPUS");
+DEFINE_int64(time_dependent_cost_update_frequency, 10000000ULL,
+             "Update frequency for time-dependent costs, in microseconds.");
 
 namespace firmament {
 namespace scheduler {
@@ -56,6 +58,7 @@ FlowScheduler::FlowScheduler(
       topology_manager_(topo_mgr),
       knowledge_base_(kb),
       parameters_(params),
+      last_updated_time_dependent_costs_(0ULL),
       leaf_res_ids_(new unordered_set<ResourceID_t,
                       boost::hash<boost::uuids::uuid>>) {
   // Select the cost model to use
@@ -256,6 +259,32 @@ void FlowScheduler::RegisterResource(ResourceID_t res_id, bool local) {
 }
 
 uint64_t FlowScheduler::RunSchedulingIteration() {
+  // If it's time to revisit time-dependent costs, do so now, just before
+  // we run the solver.
+  uint64_t cur_time = GetCurrentTimestamp();
+  if (last_updated_time_dependent_costs_ <= (cur_time -
+      static_cast<uint64_t>(FLAGS_time_dependent_cost_update_frequency))) {
+    // First collect all non-finished jobs
+    // TODO(malte): this can be removed when we've factored archived tasks
+    // and jobs out of the job_map_ into separate data structures.
+    // (cf. issue #24).
+    vector<JobDescriptor*> job_vec;
+    for (auto it = job_map_->begin();
+         it != job_map_->end();
+         ++it) {
+      // We only need to reconsider this job if it is still active
+      if (it->second.state() != JobDescriptor::COMPLETED &&
+          it->second.state() != JobDescriptor::FAILED &&
+          it->second.state() != JobDescriptor::ABORTED) {
+        job_vec.push_back(&it->second);
+      }
+    }
+    // This will re-visit all jobs and update their time-dependent costs
+    VLOG(1) << "Flow scheduler updating time-dependent costs.";
+    flow_graph_->UpdateTimeDependentCosts(&job_vec);
+    last_updated_time_dependent_costs_ = cur_time;
+  }
+  // Run the solver to get the latest scheduling assignments
   multimap<uint64_t, uint64_t>* task_mappings = solver_dispatcher_->Run();
   // Solver's done, let's post-process the results.
   multimap<uint64_t, uint64_t>::iterator it;

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -87,7 +87,11 @@ class FlowScheduler : public EventDrivenScheduler {
   SchedulingParameters parameters_;
   // The dispatcher runs different flow solvers.
   SolverDispatcher* solver_dispatcher_;
+  // The scheduler's active cost model, used to construct the flow network and
+  // assign costs to edges
   CostModelInterface* cost_model_;
+  // Timestamp when the time-dependent costs in the graph were last updated
+  uint64_t last_updated_time_dependent_costs_;
   // Set containing the resource ids of the PUs.
   unordered_set<ResourceID_t, boost::hash<boost::uuids::uuid>>* leaf_res_ids_;
 };


### PR DESCRIPTION
Some costs in the flow network can change over time (e.g., any cost based on time since submission a task). In order to update the appropriate edges in the flow network, we must repeatedly invoke `FlowGraph::AddOrUpdateJobNodes()`. If we do this too often, we will generate a huge number of incremental changes. Instead, we define a configurable minimum time interval at which the costs will be updated. 

Notw that this does not guarantee updates every _n_ seconds, however: if no events happen in the cluster, the scheduler won't be invoked and no updates will be made. This is fine, since we assume that the optimality of the previous solution still holds. We may want to re-visit this assumption later and trigger regular scheduler runs.