### PR TITLE
Whare-Map cost model implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,60 @@
+*** Firmament ***
+
+Firmament is licensed under the Apache License, version 2.0:
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this code except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+*** Libraries ***
+
+All libraries that Firmament depends on are under permissive licenses:
+ * Boost: Boost Software License
+   (http://www.boost.org/users/license.html)
+ * bzip2: BSD license
+   (http://www.bzip2.org)
+ * Ctemplate: New BSD license
+   (http://goog-ctemplate.sourceforge.net/COPYING)
+ * Flowlessly solver: New BSD license
+   (http://icgog.github.io/Flowlessly/)
+ * gperftools & tcmalloc: New BSD license
+   (http://code.google.com/p/gperftools)
+ * glog: New BSD license
+   (https://github.com/google/glog/blob/master/COPYING)
+ * gflags: New BSD license
+   (https://github.com/gflags/gflags/blob/master/COPYING.txt)
+ * googletest: New BSD license
+   (https://code.google.com/p/googletest/)
+ * hwloc: New BSD license
+   (http://www.open-mpi.org/projects/hwloc/license.php)
+ * Jansson: MIT license
+   (http://www.digip.org/jansson)
+ * OpenSSL: Apache license
+   (http://www.openssl.org/source/license.html)
+ * pion: Boost Software License
+   (http://www.boost.org/users/license.html)
+ * pb2json: MIT license
+   (https://github.com/shafreeck/pb2json/blob/master/LICENSE)
+ * protobuf: New BSD license
+   (https://github.com/google/protobuf/blob/master/LICENSE)
+
+
+*** Min-cost, max flow solvers ***
+
+Note that the "cs2" min-cost, max-flow solver is under a non-free
+license that does not permit commercial use:
+
+  https://github.com/iveney/cs2/blob/master/COPYRIGHT
+
+If you intend to use Firmament in a commercial production environment, we
+recommend that you use our free, BSD-licensed Flowlessly solver instead
+(https://github.com/ICGog/Flowlessly).

--- a/README.md
+++ b/README.md
@@ -83,8 +83,22 @@ depends on some protocol buffer data structures that need to be compiled. If
 you have run `make all`, all script dependencies should automatically have been
 built, though.)
 
-If this all works, you should see the job print "Hello world" in the
-coordinator's console.
+If this all works, you should see the new job on the web UI.
+
+## Using the flow scheduler
+
+By default, Firmament starts up with a simple queue-based scheduler. If you want
+to instead use our new scheduler based on flow network optimization, pass
+the `--scheduler flow` flag to the coordinator on startup:
+
+```
+$ build/engine/coordinator --scheduler flow --flow_scheduling_cost_model 6 --listen_uri tcp://<host>:<port> --task_lib_path=$(PWD)/build/engine/
+```
+
+The `--flow_scheduling_cost_model`` option choses the cost model on which the
+scheduler's flow network is based: here, we specify a simple load-balacing model
+that aims to put the same number of tasks on each machine. Several other cost
+models are available and in development.
 
 ## Contributing
 

--- a/scripts/job/Makefile
+++ b/scripts/job/Makefile
@@ -4,7 +4,8 @@ SUFFIX=scripts/job
 include $(ROOT_DIR)/include/Makefile.config
 include $(ROOT_DIR)/include/Makefile.common
 
-PBS=base/job_desc.proto base/task_desc.proto base/reference_desc.proto base/resource_request.proto
+PBS=base/job_desc.proto base/task_desc.proto base/reference_desc.proto \
+		base/resource_request.proto base/task_final_report.proto
 
 protobufs: $(addprefix $(SRC_ROOT_DIR)/, $(PBS))
 	protoc -I$(SRC_ROOT_DIR)/ --python_out=. $^

--- a/src/base/Makefile
+++ b/src/base/Makefile
@@ -4,7 +4,7 @@ SUFFIX=base
 include $(ROOT_DIR)/include/Makefile.config
 
 LIB = libfirmament_base.a
-OBJS = task.o resource_status.o job.o data_object.o task_graph.o
+OBJS = task.o resource_status.o job.o data_object.o
 # These need to be in a particular order to satisfy dependencies.
 # Do not reorder alphabetically.
 PBS = whare_map_stats.pb.o reference_desc.pb.o resource_request.pb.o \
@@ -13,11 +13,7 @@ PBS = whare_map_stats.pb.o reference_desc.pb.o resource_request.pb.o \
       task_final_report.pb.o machine_perf_statistics_sample.pb.o \
       ensemble_desc.pb.o data_object_name.pb.o job_desc.pb.o \
 
-TESTS = data_object_test references_test task_graph_test
-TESTS_task_graph_DEPS = $(OBJ_DIR)/data_object.o \
-      $(OBJ_DIR)/reference_desc.pb.o \
-      $(OBJ_DIR)/resource_request.pb.o \
-      $(OBJ_DIR)/task_desc.pb.o
+TESTS = data_object_test references_test
 
 OBJ_LIB = $(addprefix $(OBJ_DIR)/, $(LIB))
 #TESTS_OBJS = $(addprefix $(TEST_OBJ_DIR)/, $(TESTS))

--- a/src/base/task_desc.proto
+++ b/src/base/task_desc.proto
@@ -2,6 +2,7 @@ package firmament;
 
 import "base/reference_desc.proto";
 import "base/resource_request.proto";
+import "base/task_final_report.proto";
 
 message TaskDescriptor {
   enum TaskState {
@@ -38,19 +39,19 @@ message TaskDescriptor {
   /* Children */
   repeated TaskDescriptor spawned = 10;
   /* Runtime meta-data */
-  optional string last_heartbeat_location = 11;
-  optional uint64 last_heartbeat_time = 12;
+  optional string scheduled_to_resource = 11;
+  optional string last_heartbeat_location = 12;
+  optional uint64 last_heartbeat_time = 13;
   /* Delegation info */
-  optional string delegated_to = 13;
-  optional string delegated_from = 14;
+  optional string delegated_to = 14;
+  optional string delegated_from = 15;
   /* Timestamps */
-  optional uint64 submit_time = 15;
-  optional uint64 start_time = 16;
-  optional uint64 finish_time = 17;
+  optional uint64 submit_time = 16;
+  optional uint64 start_time = 17;
+  optional uint64 finish_time = 18;
   /* Deadlines */
-  optional uint64 relative_deadline = 18;
-  optional uint64 absolute_deadline = 19;
-  optional uint64 equivalence_class = 20;
+  optional uint64 relative_deadline = 19;
+  optional uint64 absolute_deadline = 20;
   /* Application-specific fields */
   /* TODO(malte): move these to sub-messages */
   optional uint64 port = 21;
@@ -61,4 +62,6 @@ message TaskDescriptor {
   optional ResourceRequest resource_request = 24;
   optional uint32 priority = 25;
   optional TaskType task_type = 26;
+  /* Final report after successful execution */
+  optional TaskFinalReport final_report = 27;
 }

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -105,18 +105,14 @@ typedef boost::uuids::uuid JobID_t;
 /*typedef unordered_map<ResourceID_t, ResourceStatus*,
         boost::hash<boost::uuids::uuid> > ResourceMap_t;
 typedef unordered_map<JobID_t, JobDescriptor,
-        boost::hash<boost::uuids::uuid> > JobMap_t;
-typedef unordered_map<JobID_t, TaskGraph*,
-        boost::hash<boost::uuids::uuid> > TaskGraphMap_t;*/
+        boost::hash<boost::uuids::uuid> > JobMap_t; */
 typedef thread_safe::map<ResourceID_t, ResourceStatus*> ResourceMap_t;
 typedef thread_safe::map<JobID_t, JobDescriptor> JobMap_t;
-typedef thread_safe::map<JobID_t, TaskGraph*> TaskGraphMap_t;
 #else
 typedef uint64_t ResourceID_t;
 typedef uint64_t JobID_t;
 typedef unordered_map<ResourceID_t, ResourceStatus*> ResourceMap_t;
 typedef unordered_map<JobID_t, JobDescriptor> JobMap_t;
-typedef unordered_map<JobID_t, TaskGraph*> TaskGraphMap_t;
 #endif
 // N.B.: the type of the second element here is a pointer, since the
 // TaskDescriptor objects will be part of the JobDescriptor protobuf that is

--- a/src/base/whare_map_stats.proto
+++ b/src/base/whare_map_stats.proto
@@ -6,8 +6,10 @@
 package firmament;
 
 message WhareMapStats {
-  required uint64 num_devils = 1;
-  required uint64 num_rabbits = 2;
-  required uint64 num_sheep = 3;
-  required uint64 num_turtles = 4;
+  optional uint32 num_idle = 1;
+  // ----------------------------
+  optional uint32 num_devils = 2;
+  optional uint32 num_rabbits = 3;
+  optional uint32 num_sheep = 4;
+  optional uint32 num_turtles = 5;
 }

--- a/src/engine/coordinator.cc
+++ b/src/engine/coordinator.cc
@@ -945,10 +945,6 @@ const string Coordinator::SubmitJob(const JobDescriptor& job_descriptor) {
     root_task->set_absolute_deadline(
         GetCurrentTimestamp() + root_task->relative_deadline() * 1000000);
   }
-  // Create a dynamic task graph for the job
-  TaskGraph* new_dtg = new TaskGraph(root_task);
-  // Store the task graph
-  InsertIfNotPresent(&task_graph_table_, new_job_id, new_dtg);
   // Add itself and its spawned tasks (if any) to the relevant tables:
   // - tasks to the task_table_
   // - inputs/outputs to the object_table_

--- a/src/engine/coordinator.cc
+++ b/src/engine/coordinator.cc
@@ -446,6 +446,13 @@ void Coordinator::HandleTaskFinalReport(const TaskFinalReport& report) {
   VLOG(1) << "Handling task final report for " << report.task_id();
   TaskDescriptor *td_ptr = FindPtrOrNull(*task_table_, report.task_id());
   CHECK_NOTNULL(td_ptr);
+  HandleTaskFinalReport(report, td_ptr);
+}
+
+void Coordinator::HandleTaskFinalReport(const TaskFinalReport& report,
+                                        TaskDescriptor* td_ptr) {
+  CHECK_NOTNULL(td_ptr);
+  VLOG(1) << "Handling task final report for " << report.task_id();
   // Process the report using the KB
   knowledge_base_->ProcessTaskFinalReport(report, td_ptr->uid());
 }
@@ -750,7 +757,7 @@ void Coordinator::HandleTaskCompletion(const TaskStateMessage& msg,
   }
   if (report.has_task_id()) {
     // Process the final report locally
-    knowledge_base_->ProcessTaskFinalReport(report, td_ptr->uid());
+    HandleTaskFinalReport(report, td_ptr);
   }
 }
 

--- a/src/engine/coordinator.cc
+++ b/src/engine/coordinator.cc
@@ -204,8 +204,13 @@ void Coordinator::Run() {
   // Test topology detection
   LOG(INFO) << "Detecting resource topology:";
   topology_manager_->DebugPrintRawTopology();
-  if (FLAGS_include_local_resources)
+  if (FLAGS_include_local_resources) {
+    // Add the local processing resources
     DetectLocalResources();
+  } else {
+    // We still add a node: a "virtual" resource representing this coordinator
+    AddResource(local_resource_topology_, node_uri_, true);
+  }
 
   // Coordinator starting -- set up and wait for workers to connect.
   m_adapter_->ListenURI(FLAGS_listen_uri);

--- a/src/engine/coordinator.cc
+++ b/src/engine/coordinator.cc
@@ -43,7 +43,7 @@ DEFINE_string(parent_uri, "", "The URI of the parent coordinator to register "
 DEFINE_bool(include_local_resources, true, "Add local machine's resources; "
             "will instantiate a resource-less coordinator if false.");
 DEFINE_string(scheduler, "simple", "Scheduler to use: one of 'simple' or "
-              "'quincy'.");
+              "'flow'.");
 #ifdef __HTTP_UI__
 DEFINE_bool(http_ui, true, "Enable HTTP interface");
 DEFINE_int32(http_ui_port, 8080,
@@ -87,7 +87,7 @@ Coordinator::Coordinator(PlatformID platform_id)
         object_store_, task_table_, topology_manager_, m_adapter_,
         uuid_, FLAGS_listen_uri);
     knowledge_base_->SetCostModel(new VoidCostModel());
-  } else if (FLAGS_scheduler == "quincy") {
+  } else if (FLAGS_scheduler == "flow") {
     // Quincy-style flow-based scheduling
     LOG(INFO) << "Using Quincy-style min cost flow-based scheduler.";
     SchedulingParameters params;

--- a/src/engine/coordinator.h
+++ b/src/engine/coordinator.h
@@ -253,6 +253,7 @@ class Coordinator : public Node,
   void HandleTaskDelegationResponse(const TaskDelegationResponseMessage& msg,
                                     const string& endpoint);
   void HandleTaskFinalReport(const TaskFinalReport& report);
+  void HandleTaskFinalReport(const TaskFinalReport& report, TaskDescriptor* td);
   void HandleTaskHeartbeat(const TaskHeartbeatMessage& msg);
   void HandleTaskInfoRequest(const TaskInfoRequestMessage& msg,
                              const string& remote_endpoint);

--- a/src/engine/coordinator.h
+++ b/src/engine/coordinator.h
@@ -287,9 +287,6 @@ class Coordinator : public Node,
   // A map of all tasks that the coordinator currently knows about.
   // TODO(malte): Think about GC'ing this.
   shared_ptr<TaskMap_t> task_table_;
-  // TODO(malte): figure out if we need task_table_ and job_table_ in addition
-  // to this.
-  TaskGraphMap_t task_graph_table_;
   // The health monitor periodically checks on the liveness of subordinate
   // coordinators and running tasks.
   HealthMonitor health_monitor_;

--- a/src/engine/coordinator_http_ui.cc
+++ b/src/engine/coordinator_http_ui.cc
@@ -475,7 +475,17 @@ void CoordinatorHTTPUI::HandleResourceURI(http::request_ptr& http_request,  // N
     dict.SetValue("RES_ID", rtnd_ptr->resource_desc().uuid());
     dict.SetValue("RES_FRIENDLY_NAME",
                   rtnd_ptr->resource_desc().friendly_name());
-    dict.SetValue("RES_REC", "Not implemented");
+    // Equivalence classes
+    vector<EquivClass_t>* equiv_classes =
+        coordinator_->knowledge_base()->GetResourceEquivClasses(rid);
+    if (equiv_classes) {
+      for (vector<EquivClass_t>::iterator it = equiv_classes->begin();
+           it != equiv_classes->end(); ++it) {
+        TemplateDictionary* tec_dict = dict.AddSectionDictionary("RES_RECS");
+        tec_dict->SetFormattedValue("RES_REC", "%ju", *it);
+      }
+    }
+    delete equiv_classes;
     dict.SetValue("RES_TYPE", ENUM_TO_STRING(ResourceDescriptor::ResourceType,
                                              rtnd_ptr->resource_desc().type()));
     dict.SetValue("RES_STATUS",
@@ -888,6 +898,10 @@ void CoordinatorHTTPUI::HandleTaskURI(http::request_ptr& http_request,  // NOLIN
     dict.SetValue("TASK_ARGS", arg_string);
     dict.SetValue("TASK_STATUS", ENUM_TO_STRING(TaskDescriptor::TaskState,
                                                 td_ptr->state()));
+    // Scheduled to resource
+    if (td_ptr->has_scheduled_to_resource()) {
+      dict.SetValue("TASK_SCHEDULED_TO", td_ptr->scheduled_to_resource());
+    }
     // Location
     if (td_ptr->has_last_heartbeat_location()) {
       dict.SetValue("TASK_LOCATION", td_ptr->last_heartbeat_location());
@@ -941,7 +955,7 @@ void CoordinatorHTTPUI::HandleTaskURI(http::request_ptr& http_request,  // NOLIN
       for (vector<EquivClass_t>::iterator it = equiv_classes->begin();
            it != equiv_classes->end(); ++it) {
         TemplateDictionary* tec_dict = dict.AddSectionDictionary("TASK_TECS");
-        tec_dict->SetIntValue("TASK_TEC", *it);
+        tec_dict->SetFormattedValue("TASK_TEC", "%ju", *it);
       }
     }
     delete equiv_classes;

--- a/src/engine/coordinator_http_ui.cc
+++ b/src/engine/coordinator_http_ui.cc
@@ -184,8 +184,8 @@ void CoordinatorHTTPUI::HandleRootURI(http::request_ptr& http_request,  // NOLIN
   // Scheduler information
   if (FLAGS_scheduler == "simple") {
     dict.SetValue("SCHEDULER_NAME", "queue-based");
-  } else if (FLAGS_scheduler == "quincy") {
-    dict.SetValue("SCHEDULER_NAME", "flow optimization");
+  } else if (FLAGS_scheduler == "flow") {
+    dict.SetValue("SCHEDULER_NAME", "flow network optimization");
     const FlowScheduler* sched =
       dynamic_cast<const FlowScheduler*>(coordinator_->scheduler());
     for (uint64_t i = 0; i < sched->dispatcher().seq_num(); ++i) {

--- a/src/engine/coordinator_http_ui.cc
+++ b/src/engine/coordinator_http_ui.cc
@@ -635,6 +635,8 @@ void CoordinatorHTTPUI::HandleSchedURI(http::request_ptr& http_request,  // NOLI
                                        tcp::connection_ptr& tcp_conn) {  // NOLINT
   LogRequest(http_request);
   http::response_writer_ptr writer = InitOkResponse(http_request, tcp_conn);
+  // XXX(malte): HACK!
+  system("bash scripts/plot_flow_graph.sh");
   // Get resource information from coordinator
   string iter_id = http_request->get_query("iter");
   if (iter_id.empty()) {

--- a/src/engine/coordinator_http_ui.cc
+++ b/src/engine/coordinator_http_ui.cc
@@ -357,6 +357,27 @@ void CoordinatorHTTPUI::HandleJobURI(http::request_ptr& http_request,  // NOLINT
   FinishOkResponse(writer);
 }
 
+void CoordinatorHTTPUI::HandleECDetailsURI(http::request_ptr& http_request,  // NOLINT
+                                           tcp::connection_ptr& tcp_conn) {  // NOLINT
+  LogRequest(http_request);
+  http::response_writer_ptr writer = InitOkResponse(http_request, tcp_conn);
+  string ec_id = http_request->get_query("id");
+  if (ec_id.empty()) {
+    ErrorResponse(http::types::RESPONSE_CODE_SERVER_ERROR, http_request,
+                  tcp_conn);
+    return;
+  }
+  TemplateDictionary dict("ec_details");
+  dict.SetFormattedValue("EC_ID", "%llu", strtoull(ec_id.c_str(), 0, 10));
+  AddHeaderToTemplate(&dict, coordinator_->uuid(), NULL);
+  AddFooterToTemplate(&dict);
+  string output;
+  ExpandTemplate("src/webui/ec_details.tpl", ctemplate::DO_NOT_STRIP,
+                 &dict, &output);
+  writer->write(output);
+  FinishOkResponse(writer);
+}
+
 void CoordinatorHTTPUI::HandleReferencesListURI(http::request_ptr& http_request,  // NOLINT
                                                 tcp::connection_ptr& tcp_conn) {  // NOLINT
   LogRequest(http_request);
@@ -684,8 +705,11 @@ void CoordinatorHTTPUI::HandleStatisticsURI(http::request_ptr& http_request,  //
   // Get resource information from coordinator
   string res_id = http_request->get_query("res");
   string task_id = http_request->get_query("task");
-  if (!(res_id.empty() || task_id.empty()) ||
-      (res_id.empty() && task_id.empty())) {
+  string ec_id = http_request->get_query("ec");
+  if ((res_id.empty() && task_id.empty() && ec_id.empty()) ||
+      !(res_id.empty() || task_id.empty()) ||
+      !(res_id.empty() || ec_id.empty()) ||
+      !(task_id.empty() || ec_id.empty())) {
     ErrorResponse(http::types::RESPONSE_CODE_SERVER_ERROR, http_request,
                   tcp_conn);
     LOG(WARNING) << "Invalid stats request!";
@@ -743,7 +767,25 @@ void CoordinatorHTTPUI::HandleStatisticsURI(http::request_ptr& http_request,  //
     output += "]";
     output += ", \"reports\": [";
     const deque<TaskFinalReport>* report_result =
-      coordinator_->knowledge_base()->GetFinalStatsForTask(td->uid());
+      coordinator_->knowledge_base()->GetFinalReportForTask(td->uid());
+    if (report_result) {
+      bool first = true;
+      for (deque<TaskFinalReport>::const_iterator it =
+          report_result->begin();
+          it != report_result->end();
+          ++it) {
+        if (!first)
+          output += ", ";
+        output += pb2json(*it);
+        first = false;
+      }
+    }
+    output += "] }";
+  } else if (!ec_id.empty()) {
+    output += "{ \"reports\": [";
+    const deque<TaskFinalReport>* report_result =
+      coordinator_->knowledge_base()->GetFinalReportsForTEC(
+          strtoull(ec_id.c_str(), 0, 10));
     if (report_result) {
       bool first = true;
       for (deque<TaskFinalReport>::const_iterator it =
@@ -758,7 +800,7 @@ void CoordinatorHTTPUI::HandleStatisticsURI(http::request_ptr& http_request,  //
     }
     output += "] }";
   } else {
-    LOG(FATAL) << "Neither task_id nor res_id set, but they should be!";
+    LOG(FATAL) << "Neither task_id, nor ec_id, nor res_id set, but they should be!";
   }
   writer->write(output);
   FinishOkResponse(writer);
@@ -796,7 +838,6 @@ void CoordinatorHTTPUI::HandleTasksListURI(http::request_ptr& http_request,  // 
   writer->write(output);
   FinishOkResponse(writer);
 }
-
 
 void CoordinatorHTTPUI::HandleTaskURI(http::request_ptr& http_request,  // NOLINT
                                       tcp::connection_ptr& tcp_conn) {  // NOLINT
@@ -1089,6 +1130,9 @@ void __attribute__((no_sanitize_address)) CoordinatorHTTPUI::Init(
     // Collectl raw data hook
     coordinator_http_server_->add_resource("/collectl/raw/", boost::bind(
         &CoordinatorHTTPUI::HandleCollectlRawURI, this, _1, _2));
+    // Equivalence class details
+    coordinator_http_server_->add_resource("/ec/", boost::bind(
+        &CoordinatorHTTPUI::HandleECDetailsURI, this, _1, _2));
     // Job list
     coordinator_http_server_->add_resource("/jobs/", boost::bind(
         &CoordinatorHTTPUI::HandleJobsListURI, this, _1, _2));

--- a/src/engine/coordinator_http_ui.cc
+++ b/src/engine/coordinator_http_ui.cc
@@ -719,6 +719,18 @@ void CoordinatorHTTPUI::HandleSchedURI(http::request_ptr& http_request,  // NOLI
   FinishOkResponse(writer);
 }
 
+void CoordinatorHTTPUI::HandleSchedCostModelURI(http::request_ptr& http_request,  // NOLINT
+                                                tcp::connection_ptr& tcp_conn) {  // NOLINT
+  LogRequest(http_request);
+  http::response_writer_ptr writer = InitOkResponse(http_request, tcp_conn);
+  // Get resource information from coordinator
+  const FlowScheduler* sched =
+    dynamic_cast<const FlowScheduler*>(coordinator_->scheduler());
+  string output = sched->cost_model().DebugInfo();
+  writer->write(output);
+  FinishOkResponse(writer);
+}
+
 void CoordinatorHTTPUI::HandleSchedFlowGraphURI(http::request_ptr& http_request,  // NOLINT
                                                 tcp::connection_ptr& tcp_conn) {  // NOLINT
   LogRequest(http_request);
@@ -1232,6 +1244,9 @@ void __attribute__((no_sanitize_address)) CoordinatorHTTPUI::Init(
     // Scheduler live flow graph JSON
     coordinator_http_server_->add_resource("/sched/flowgraph/", boost::bind(
         &CoordinatorHTTPUI::HandleSchedFlowGraphURI, this, _1, _2));
+    // Scheduler cost model JSON
+    coordinator_http_server_->add_resource("/sched/costmodel/", boost::bind(
+        &CoordinatorHTTPUI::HandleSchedCostModelURI, this, _1, _2));
     // Statistics data serving pages
     coordinator_http_server_->add_resource("/stats/", boost::bind(
         &CoordinatorHTTPUI::HandleStatisticsURI, this, _1, _2));

--- a/src/engine/coordinator_http_ui.h
+++ b/src/engine/coordinator_http_ui.h
@@ -81,6 +81,8 @@ class CoordinatorHTTPUI {
                                tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleSchedURI(http::request_ptr& http_request, // NOLINT
                       tcp::connection_ptr& tcp_conn);  // NOLINT
+  void HandleSchedCostModelURI(http::request_ptr& http_request, // NOLINT
+                               tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleSchedFlowGraphURI(http::request_ptr& http_request, // NOLINT
                                tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleStatisticsURI(http::request_ptr& http_request, // NOLINT

--- a/src/engine/coordinator_http_ui.h
+++ b/src/engine/coordinator_http_ui.h
@@ -81,6 +81,8 @@ class CoordinatorHTTPUI {
                                tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleSchedURI(http::request_ptr& http_request, // NOLINT
                       tcp::connection_ptr& tcp_conn);  // NOLINT
+  void HandleSchedFlowGraphURI(http::request_ptr& http_request, // NOLINT
+                               tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleStatisticsURI(http::request_ptr& http_request, // NOLINT
                            tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleTasksListURI(http::request_ptr& http_request, // NOLINT

--- a/src/engine/coordinator_http_ui.h
+++ b/src/engine/coordinator_http_ui.h
@@ -61,6 +61,8 @@ class CoordinatorHTTPUI {
                           tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleJobDTGURI(http::request_ptr& http_request, // NOLINT
                        tcp::connection_ptr& tcp_conn);  // NOLINT
+  void HandleECDetailsURI(http::request_ptr& http_request, // NOLINT
+                          tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleLogURI(http::request_ptr& http_request, // NOLINT
                     tcp::connection_ptr& tcp_conn);  // NOLINT
   void HandleRootURI(http::request_ptr& http_request, // NOLINT

--- a/src/engine/local_executor.cc
+++ b/src/engine/local_executor.cc
@@ -456,6 +456,13 @@ void LocalExecutor::SetUpEnvironmentForTask(
   if (td.inject_task_lib()) {
     InsertIfNotPresent(env, "LD_LIBRARY_PATH", FLAGS_task_lib_dir);
     InsertIfNotPresent(env, "LD_PRELOAD", "task_lib_inject.so");
+    // This effectively does a "basename" on the executable; the TASK_COMM
+    // environment variable is used to match the executable for against
+    // /proc/self/comm when deciding whether to inject a monitor thread.
+    string expected_comm =
+      td.binary().substr(td.binary().rfind("/") + 1,
+                         td.binary().size() - td.binary().rfind("/") - 1);
+    InsertIfNotPresent(env, "TASK_COMM", expected_comm);
   }
   VLOG(1) << "Task's environment variables:";
   for (unordered_map<string, string>::const_iterator env_iter = env->begin();

--- a/src/messages/task_state_message.proto
+++ b/src/messages/task_state_message.proto
@@ -1,17 +1,15 @@
 // The Firmament project
 // Copyright (c) 2011-2012 Malte Schwarzkopf <malte.schwarzkopf@cl.cam.ac.uk>
 //
-// HeartbeatMessage is a simple keep-alive message that reports on a live
-// resource. It may also trigger registration and fault recovery, although
-// initial registration is triggered explicitly using RegistrationMessage.
+// TaskStateMessage indicates a state change of a task.
 
 package firmament;
 
 import "base/task_desc.proto";
 import "base/task_final_report.proto";
 
-
 message TaskStateMessage {
   optional uint64 id = 1;
   required TaskDescriptor.TaskState new_state = 2;
+  optional TaskFinalReport report = 3;
 }

--- a/src/misc/utils.cc
+++ b/src/misc/utils.cc
@@ -24,12 +24,6 @@ extern "C" {
 #include <sys/prctl.h>
 #endif
 
-#ifdef OPEN_MAX
-#define OPEN_MAX_GUESS OPEN_MAX
-#else
-#define OPEN_MAX_GUESS 256 // reasonable value
-#endif
-
 #include "misc/utils.h"
 
 namespace firmament {

--- a/src/misc/utils.h
+++ b/src/misc/utils.h
@@ -27,6 +27,12 @@ using google::protobuf::EnumDescriptor;
 
 #define ENUM_TO_STRING(t, v) t ## _descriptor()->FindValueByNumber(v)->name()
 
+#ifdef OPEN_MAX
+#define OPEN_MAX_GUESS OPEN_MAX
+#else
+#define OPEN_MAX_GUESS 256 // reasonable value
+#endif
+
 // Returns the current epoch timestamp in µ-seconds as an integer.
 // Uses gettimeofday() under the hood, so does not make any guarantees w.r.t.
 // time zones etc.

--- a/src/scheduling/event_driven_scheduler.cc
+++ b/src/scheduling/event_driven_scheduler.cc
@@ -115,6 +115,7 @@ void EventDrivenScheduler::BindTaskToResource(
   exec->RunTask(task_desc, !task_desc->inject_task_lib());
   // Mark task as running and report
   task_desc->set_state(TaskDescriptor::RUNNING);
+  task_desc->set_scheduled_to_resource(res_desc->uuid());
   VLOG(1) << "Task " << task_desc->uid() << " running.";
 }
 
@@ -213,6 +214,8 @@ void EventDrivenScheduler::HandleTaskCompletion(TaskDescriptor* td_ptr,
   ExecutorInterface* exec = FindPtrOrNull(executors_, res_id_tmp);
   CHECK_NOTNULL(exec);
   exec->HandleTaskCompletion(td_ptr, report);
+  // Store the final report in the TD for future reference
+  td_ptr->mutable_final_report()->CopyFrom(*report);
 }
 
 void EventDrivenScheduler::HandleTaskEviction(TaskDescriptor* td_ptr,

--- a/src/scheduling/flow/Makefile
+++ b/src/scheduling/flow/Makefile
@@ -10,8 +10,8 @@ LIB = libfirmament_scheduling_flow.a
 OBJS = coco_cost_model.o dimacs_add_node.o dimacs_change_arc.o \
        dimacs_change_stats.o dimacs_exporter.o dimacs_new_arc.o \
        dimacs_remove_node.o flow_graph.o flow_graph_arc.o \
-       flow_graph_node.o flow_scheduler.o octopus_cost_model.o \
-       quincy_cost_model.o simulated_quincy_cost_model.o \
+       flow_graph_node.o flow_scheduler.o json_exporter.o \
+       octopus_cost_model.o quincy_cost_model.o simulated_quincy_cost_model.o \
        sjf_cost_model.o solver_dispatcher.o trivial_cost_model.o \
        random_cost_model.o void_cost_model.o wharemap_cost_model.o
 PBS = scheduling_parameters.pb.o

--- a/src/scheduling/flow/cost_model_interface.h
+++ b/src/scheduling/flow/cost_model_interface.h
@@ -155,6 +155,16 @@ class CostModelInterface {
 
   virtual FlowGraphNode* UpdateStats(FlowGraphNode* accumulator,
                                      FlowGraphNode* other) = 0;
+
+  /**
+   * Handle to pull debug information from cost model; return string.
+   */
+  virtual const string DebugInfo() const {
+    // Default no-op implementation;
+    LOG(INFO) << "Got to interface's DebugInfo";
+    return "";
+  }
+
   inline void SetFlowGraph(shared_ptr<FlowGraph> flow_graph) {
     flow_graph_ = flow_graph;
   }

--- a/src/scheduling/flow/flow_graph.cc
+++ b/src/scheduling/flow/flow_graph.cc
@@ -719,6 +719,10 @@ void FlowGraph::ConfigureResourceLeafNode(
             << arc->cap_upper_bound_ << " -> "
             << arc->cap_upper_bound_ + 1 << ")";
     arc->cap_upper_bound_ += 1;
+    // TODO(malte): we don't set the cost here, but probably should. However,
+    // care needs to be taken, because ConfigureResourceLeafNode is called
+    // before cost model state is set up, so not all information may be
+    // available.
 
     DIMACSChange *chg = new DIMACSChangeArc(*arc);
     chg->set_comment("ConfigureResourceLeafNode");

--- a/src/scheduling/flow/flow_graph.cc
+++ b/src/scheduling/flow/flow_graph.cc
@@ -479,7 +479,6 @@ void FlowGraph::AddEquivClassNode(EquivClass_t ec) {
     for (vector<TaskID_t>::iterator it = task_pref_arcs->begin();
          it != task_pref_arcs->end(); ++it) {
       FlowGraphNode* task_node = NodeForTaskID(*it);
-      CHECK_NOTNULL(task_node);
       CHECK(task_node != NULL) << "Task ID requested was " << *it;
       FlowGraphArc* ec_arc =
         AddArcInternal(task_node->id_, ec_node->id_);

--- a/src/scheduling/flow/flow_graph.cc
+++ b/src/scheduling/flow/flow_graph.cc
@@ -143,9 +143,6 @@ void FlowGraph::AddArcsFromToOtherEquivNodes(EquivClass_t equiv_class,
   pair<vector<EquivClass_t>*,
        vector<EquivClass_t>*> equiv_class_to_connect =
     cost_model_->GetEquivClassToEquivClassesArcs(equiv_class);
-  if (!equiv_class_to_connect.first && !equiv_class_to_connect.second)
-    // Nothing to do, no source or destination equivalence classes
-    return;
   // Add incoming arcs.
   if (equiv_class_to_connect.first) {
     for (vector<EquivClass_t>::iterator
@@ -470,16 +467,11 @@ void FlowGraph::AddEquivClassNode(EquivClass_t ec) {
     // Add the incoming arcs to the equivalence class node.
     for (vector<TaskID_t>::iterator it = task_pref_arcs->begin();
          it != task_pref_arcs->end(); ++it) {
-<<<<<<< HEAD
       FlowGraphNode* task_node = NodeForTaskID(*it);
       CHECK_NOTNULL(task_node);
       CHECK(task_node != NULL) << "Task ID requested was " << *it;
       FlowGraphArc* ec_arc =
         AddArcInternal(task_node->id_, ec_node->id_);
-=======
-      FlowGraphArc* ec_arc =
-        AddArcInternal(NodeForTaskID(*it)->id_, ec_node->id_);
->>>>>>> f5b21e90cd806ae46742435f6e28bcf9507bc4d7
       // XXX(ionel): Increase the capacity if we want to allow for PU sharing.
       ec_arc->cap_upper_bound_ = 1;
       ec_arc->cost_ =

--- a/src/scheduling/flow/flow_graph.cc
+++ b/src/scheduling/flow/flow_graph.cc
@@ -495,7 +495,18 @@ void FlowGraph::AddEquivClassNode(EquivClass_t ec) {
     for (vector<TaskID_t>::iterator it = task_pref_arcs->begin();
          it != task_pref_arcs->end(); ++it) {
       FlowGraphNode* task_node = NodeForTaskID(*it);
-      CHECK(task_node != NULL) << "Task ID requested was " << *it;
+      // The equivalence class may contain many tasks, and not all of them
+      // may have corresponding task nodes in the flow graph yet. This is the
+      // case for example when a job with many tasks is added and we process
+      // AddEquivClassNode for the first time. It's fine to simply ignore the
+      // not-yet-existing tasks here, because we know that we will come back
+      // later and call in here again, with the task present, at which point
+      // the correct arc will be added.
+      // TODO(malte): think about whether we can do this more elegantly; the
+      // above implicit assumption may not always hold (even though it does
+      // for now).
+      if (!task_node)
+        continue;
       FlowGraphArc* ec_arc =
         AddArcInternal(task_node->id_, ec_node->id_);
       // XXX(ionel): Increase the capacity if we want to allow for PU sharing.

--- a/src/scheduling/flow/flow_graph.h
+++ b/src/scheduling/flow/flow_graph.h
@@ -23,6 +23,7 @@
 #include "scheduling/flow/flow_graph_node.h"
 
 DECLARE_bool(preemption);
+DECLARE_string(flow_scheduling_solver);
 
 namespace firmament {
 
@@ -75,7 +76,15 @@ class FlowGraph {
     return unsched_agg_nodes_;
   }
   inline uint64_t NumArcs() const { return arc_set_.size(); }
-  inline uint64_t NumNodes() const { return node_map_.size(); }
+  inline uint64_t NumNodes() const {
+    if (FLAGS_flow_scheduling_solver != "cs2") {
+      return node_map_.size();
+    } else {
+      // TODO(malte): This is a work-around as cs2 does not allow sparse node
+      // IDs, and will get tripped up if current_id > graph.NumNodes().
+      return current_id_;
+    }
+  }
   inline FlowGraphNode* Node(uint64_t id) {
     FlowGraphNode* const* npp = FindOrNull(node_map_, id);
     return (npp ? *npp : NULL);

--- a/src/scheduling/flow/flow_graph.h
+++ b/src/scheduling/flow/flow_graph.h
@@ -40,6 +40,8 @@ class FlowGraph {
   void AddResourceTopology(
       ResourceTopologyNodeDescriptor* resource_tree);
   void AdjustUnscheduledAggArcCosts();
+  uint64_t CapacityBetweenECNodes(const FlowGraphNode& src,
+                                  const FlowGraphNode& dst);
   void ChangeArc(FlowGraphArc* arc, uint64_t cap_lower_bound,
                  uint64_t cap_upper_bound, uint64_t cost,
                  const char *comment = "ChangeArc");

--- a/src/scheduling/flow/flow_scheduler.cc
+++ b/src/scheduling/flow/flow_scheduler.cc
@@ -302,6 +302,7 @@ uint64_t FlowScheduler::RunSchedulingIteration() {
       CostModelType::COST_MODEL_OCTOPUS ||
       FLAGS_flow_scheduling_cost_model ==
       CostModelType::COST_MODEL_WHARE) {
+    LOG(INFO) << "Updating resource statistics in flow graph";
     flow_graph_->ComputeTopologyStatistics(
         flow_graph_->sink_node(),
         boost::bind(&CostModelInterface::GatherStats,

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -74,6 +74,7 @@ class FlowScheduler : public EventDrivenScheduler {
   void RegisterLocalResource(ResourceID_t res_id);
   void RegisterRemoteResource(ResourceID_t res_id);
   uint64_t RunSchedulingIteration();
+  void UpdateCostModelResourceStats();
   void UpdateResourceTopology(
       ResourceTopologyNodeDescriptor* resource_tree);
 

--- a/src/scheduling/flow/flow_scheduler.h
+++ b/src/scheduling/flow/flow_scheduler.h
@@ -60,6 +60,9 @@ class FlowScheduler : public EventDrivenScheduler {
                    << parameters_.DebugString() << ">";
   }
 
+  const CostModelInterface& cost_model() const {
+    return *cost_model_;
+  }
   const SolverDispatcher& dispatcher() const {
     return *solver_dispatcher_;
   }

--- a/src/scheduling/flow/json_exporter.cc
+++ b/src/scheduling/flow/json_exporter.cc
@@ -1,0 +1,106 @@
+// The Firmament project
+// Copyright (c) 2015 Malte Schwarzkopf <malte.schwarzkopf@cl.cam.ac.uk>
+//
+// Implementation of export utility that converts a given resource topology and
+// a JSON object for use e.g. with viz.js.
+
+#include "scheduling/flow/json_exporter.h"
+
+#include <string>
+#include <cstdio>
+
+#include "misc/pb_utils.h"
+
+namespace firmament {
+
+using machine::topology::TopologyManager;
+
+JSONExporter::JSONExporter() {
+}
+
+void JSONExporter::Export(const FlowGraph& graph, string* output) const {
+  // Problem header
+  *output += GenerateHeader(graph.NumNodes(), graph.NumArcs());
+  *output += "\"nodes\": [";
+  for (unordered_map<uint64_t, FlowGraphNode*>::const_iterator n_iter =
+       graph.Nodes().begin();
+       n_iter != graph.Nodes().end();
+       ++n_iter) {
+    if (n_iter != graph.Nodes().begin())
+      *output += ",\n";
+    *output += GenerateNode(*n_iter->second);
+  }
+  *output += "],\n";
+
+  *output += "\"edges\": [";
+  for (unordered_set<FlowGraphArc*>::const_iterator a_iter =
+       graph.Arcs().begin();
+       a_iter != graph.Arcs().end();
+       ++a_iter) {
+    if (a_iter != graph.Arcs().begin())
+      *output += ",\n";
+    *output += GenerateArc(**a_iter);
+  }
+  *output += "]\n";
+  *output += GenerateFooter();
+}
+
+const string JSONExporter::GenerateArc(const FlowGraphArc& arc) const {
+  stringstream ss;
+  ss << "{ \"from\": " << arc.src_ << ", \"to\": " << arc.dst_
+     << ", \"label\": \"cap: " << arc.cap_lower_bound_ << "/"
+     << arc.cap_upper_bound_ << ", c: " << arc.cost_ << "\" }";
+  return ss.str();
+}
+
+const string JSONExporter::GenerateComment(const string& text) const {
+  stringstream ss;
+  ss << "/* " << text << " */";
+  return ss.str();
+}
+
+const string JSONExporter::GenerateFooter() const {
+  stringstream ss;
+  ss << " }";
+  return ss.str();
+}
+
+const string JSONExporter::GenerateHeader(uint64_t num_nodes,
+                                          uint64_t num_arcs) const {
+  stringstream ss;
+  ss << "{ ";
+  return ss.str();
+}
+
+const string JSONExporter::GenerateNode(const FlowGraphNode& node) const {
+  stringstream ss;
+  stringstream label;
+  string node_shape;
+  string node_color;
+  if (node.type_ == FlowNodeType::SINK) {
+    node_shape = "diamond";
+    node_color = "#cccccc";
+  } else {
+    node_shape = "box";
+    if (node.type_ == FlowNodeType::UNSCHEDULED_TASK) {
+      node_color = "#ff0000";
+    } else if (node.type_ == FlowNodeType::SCHEDULED_TASK) {
+      node_color = "#00ff00";
+    } else {
+      node_color = "#ffffff";
+    }
+  }
+  if (node.comment_ != "") {
+    label << node.comment_;
+  } else if (!node.resource_id_.is_nil()) {
+    label << "res: " << to_string(node.resource_id_);
+  } else if (node.task_id_) {
+    label << "tsk: " << node.task_id_;
+  }
+  ss << "{ \"id\": " << node.id_ << ", \"label\": \"" << label.str() << "\", "
+     << "\"shape\": \"" << node_shape << "\", "
+     << "\"color\": { \"background\": \"" << node_color << "\" } }";
+  return ss.str();
+}
+
+}  // namespace firmament

--- a/src/scheduling/flow/json_exporter.h
+++ b/src/scheduling/flow/json_exporter.h
@@ -1,0 +1,38 @@
+// The Firmament project
+// Copyright (c) 2015 Malte Schwarzkopf <malte.schwarzkopf@cl.cam.ac.uk>
+//
+// Export utility that converts a given resource topology and set of job's into
+// a JSON object for use e.g. with viz.js.
+
+#ifndef FIRMAMENT_SCHEDULING_FLOW_JSON_EXPORTER_H
+#define FIRMAMENT_SCHEDULING_FLOW_JSON_EXPORTER_H
+
+#include <string>
+#include <vector>
+
+#include "base/common.h"
+#include "base/types.h"
+#include "base/resource_topology_node_desc.pb.h"
+#include "engine/topology_manager.h"
+#include "scheduling/flow/flow_graph.h"
+#include "scheduling/flow/flow_graph_arc.h"
+#include "scheduling/flow/flow_graph_node.h"
+
+namespace firmament {
+
+class JSONExporter {
+ public:
+  JSONExporter();
+  void Export(const FlowGraph& graph, string* output) const;
+
+ private:
+  const string GenerateArc(const FlowGraphArc& arc) const;
+  const string GenerateComment(const string& text) const;
+  const string GenerateFooter() const;
+  const string GenerateHeader(uint64_t num_nodes, uint64_t num_arcs) const;
+  const string GenerateNode(const FlowGraphNode& node) const;
+};
+
+}  // namespace firmament
+
+#endif  // FIRMAMENT_SCHEDULING_FLOW_JSON_EXPORTER_H

--- a/src/scheduling/flow/solver_dispatcher.h
+++ b/src/scheduling/flow/solver_dispatcher.h
@@ -10,6 +10,7 @@
 #include "base/common.h"
 #include "scheduling/scheduling_delta.pb.h"
 #include "scheduling/flow/dimacs_exporter.h"
+#include "scheduling/flow/json_exporter.h"
 #include "scheduling/flow/flow_graph.h"
 
 namespace firmament {
@@ -19,6 +20,7 @@ class SolverDispatcher {
  public:
   SolverDispatcher(shared_ptr<FlowGraph> flow_graph, bool solver_ran_once);
 
+  void ExportJSON(string* output) const;
   void NodeBindingToSchedulingDelta(
       const TaskDescriptor& task, const ResourceDescriptor& res,
       unordered_map<TaskID_t, ResourceID_t>* task_bindings,
@@ -46,7 +48,9 @@ class SolverDispatcher {
 
   shared_ptr<FlowGraph> flow_graph_;
   // DIMACS exporter for interfacing to the solver
-  DIMACSExporter exporter_;
+  DIMACSExporter dimacs_exporter_;
+  // JSON exporter for debug and visualisation
+  JSONExporter json_exporter_;
   // Boolean that indicates if the solver has knowledge of the flow graph (i.e.
   // it is set after the initial from scratch run of the solver).
   bool solver_ran_once_;

--- a/src/scheduling/flow/solver_dispatcher.h
+++ b/src/scheduling/flow/solver_dispatcher.h
@@ -17,11 +17,7 @@ namespace scheduler {
 
 class SolverDispatcher {
  public:
-  SolverDispatcher(shared_ptr<FlowGraph> flow_graph, bool solver_ran_once)
-    : flow_graph_(flow_graph),
-      solver_ran_once_(solver_ran_once),
-      debug_seq_num_(0) {
-  }
+  SolverDispatcher(shared_ptr<FlowGraph> flow_graph, bool solver_ran_once);
 
   void NodeBindingToSchedulingDelta(
       const TaskDescriptor& task, const ResourceDescriptor& res,

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -67,7 +67,11 @@ const string WhareMapCostModel::DebugInfo() const {
     ss << "  <" << it->first.first << ", " << it->first.second << "> -> "
        << "avg: " << AverageFromVec(*it->second) << ", "
        << "min: " << MinFromVec(*it->second) << ", "
-       << "max: " << MaxFromVec(*it->second) << "." << endl;
+       << "max: " << MaxFromVec(*it->second) << "; ";
+    ss << "[";
+    for (auto vit = it->second->begin(); vit != it->second->end(); ++vit)
+      ss << *vit << ", ";
+    ss << "]" << endl;
     out += ss.str();
   }
   return out;

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -502,7 +502,7 @@ void WhareMapCostModel::RecordECtoPsPIMapping(
   VLOG(1) << "Instructions: " << task_report.instructions();
   if (task_report.instructions() > 0) {
     uint64_t pspi_value =
-      (static_cast<uint64_t>(task_report.runtime()) * 10000000000) /
+      (static_cast<uint64_t>(task_report.runtime()) * SECONDS_TO_PICOSECONDS) /
       task_report.instructions();
     if (!pspi_vec) {
       pspi_vec = new vector<uint64_t>();

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -59,7 +59,8 @@ Cost_t WhareMapCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
   VLOG(1) << "Avg PsPI for TEC " << equiv_classes->front() << " is "
           << avg_pspi;
   delete equiv_classes;
-  return max(WAIT_TIME_MULTIPLIER * wait_time_centamillis, avg_pspi + 1);
+  return COST_LOWER_BOUND + max(WAIT_TIME_MULTIPLIER * wait_time_centamillis,
+                                avg_pspi + 1);
 }
 
 // The cost from the unscheduled to the sink is 0. Setting it to a value greater
@@ -102,7 +103,21 @@ Cost_t WhareMapCostModel::TaskToResourceNodeCost(TaskID_t task_id,
 Cost_t WhareMapCostModel::ResourceNodeToResourceNodeCost(
     ResourceID_t source,
     ResourceID_t destination) {
-  // TODO(ionel): Implement!
+  ResourceStatus* rs = FindPtrOrNull(*resource_map_, destination);
+  CHECK_NOTNULL(rs);
+  ResourceTopologyNodeDescriptor* rtnd = rs->mutable_topology_node();
+  // Below is a somewhat hackish way of making sure that tasks spread out
+  // across machines: we assign a baseline cost equal to the core ID for each
+  // core. The core ID is extracted from the description string...
+  if (rtnd->resource_desc().type() ==  ResourceDescriptor::RESOURCE_PU) {
+    string label = rtnd->resource_desc().friendly_name();
+    uint64_t idx = label.find("PU #");
+    if (idx != string::npos) {
+      string core_id_substr = label.substr(idx + 4, label.size() - idx - 4);
+      int64_t core_id = strtoll(core_id_substr.c_str(), 0, 10);
+      return core_id;
+    }
+  }
   return 0LL;
 }
 

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -426,30 +426,36 @@ void WhareMapCostModel::RecordECtoPsPIMapping(
   vector<uint64_t>* pspi_vec = FindPtrOrNull(psi_map_, ec_pair);
   VLOG(1) << "Runtime: " << task_report.runtime();
   VLOG(1) << "Instructions: " << task_report.instructions();
-  uint64_t pspi_value =
-    (static_cast<uint64_t>(task_report.runtime()) * 10000000000) /
-    task_report.instructions();
-  if (!pspi_vec) {
-    pspi_vec = new vector<uint64_t>();
-    InsertIfNotPresent(&psi_map_, ec_pair, pspi_vec);
+  if (task_report.instructions() > 0) {
+    uint64_t pspi_value =
+      (static_cast<uint64_t>(task_report.runtime()) * 10000000000) /
+      task_report.instructions();
+    if (!pspi_vec) {
+      pspi_vec = new vector<uint64_t>();
+      InsertIfNotPresent(&psi_map_, ec_pair, pspi_vec);
+    }
+    pspi_vec->push_back(pspi_value);
+    // Now check if this is a new worst-case; if so, record it
+    uint64_t new_avg_pspi = 0ULL;
+    for (auto it = pspi_vec->begin();
+         it != pspi_vec->end();
+         ++it) {
+      new_avg_pspi += *it;
+    }
+    new_avg_pspi /= pspi_vec->size();
+    uint64_t* cur_worst_avg_pspi =
+      FindOrNull(worst_case_psi_map_, ec_pair.first);
+    if (!cur_worst_avg_pspi || new_avg_pspi > *cur_worst_avg_pspi) {
+      InsertOrUpdate(&worst_case_psi_map_, ec_pair.first, new_avg_pspi);
+    }
+    VLOG(1) << "Recording a psPi mapping: <" << ec_pair.first << ", "
+            << ec_pair.second << "> -> " << pspi_value << ", now have "
+            << pspi_vec->size() << " samples.";
+  } else {
+    LOG(WARNING) << "No instruction count in final report for task "
+                 << task_report.task_id() << ", so did not record any "
+                 << "information for it!";
   }
-  pspi_vec->push_back(pspi_value);
-  // Now check if this is a new worst-case; if so, record it
-  uint64_t new_avg_pspi = 0ULL;
-  for (auto it = pspi_vec->begin();
-       it != pspi_vec->end();
-       ++it) {
-    new_avg_pspi += *it;
-  }
-  new_avg_pspi /= pspi_vec->size();
-  uint64_t* cur_worst_avg_pspi =
-    FindOrNull(worst_case_psi_map_, ec_pair.first);
-  if (!cur_worst_avg_pspi || new_avg_pspi > *cur_worst_avg_pspi) {
-    InsertOrUpdate(&worst_case_psi_map_, ec_pair.first, new_avg_pspi);
-  }
-  VLOG(1) << "Recording a psPi mapping: <" << ec_pair.first << ", "
-          << ec_pair.second << "> -> " << pspi_value << ", now have "
-          << pspi_vec->size() << " samples.";
 }
 
 void WhareMapCostModel::RemoveTask(TaskID_t task_id) {

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -137,9 +137,20 @@ Cost_t WhareMapCostModel::EquivClassToResourceNode(EquivClass_t tec,
   return 0LL;
 }
 
-Cost_t WhareMapCostModel::EquivClassToEquivClass(EquivClass_t tec1,
-                                                 EquivClass_t tec2) {
-  // TODO(ionel): Implement!
+Cost_t WhareMapCostModel::EquivClassToEquivClass(EquivClass_t ec1,
+                                                 EquivClass_t ec2) {
+  pair<EquivClass_t, EquivClass_t> ec_pair(ec1, ec2);
+  vector<uint64_t>* pspi_vec = FindPtrOrNull(psi_map_, ec_pair);
+  if (pspi_vec) {
+    uint64_t acc = 0;
+    for (auto it = pspi_vec->begin();
+         it != pspi_vec->end();
+         ++it) {
+      acc += *it;
+    }
+    // Average PsPI for tasks in ec1 on machine of type ec2
+    return (acc / pspi_vec->size());
+  }
   return 0LL;
 }
 
@@ -200,28 +211,35 @@ vector<ResourceID_t>* WhareMapCostModel::GetOutgoingEquivClassPrefArcs(
     }
   } else if (task_aggs_.find(ec) != task_aggs_.end()) {
     // ec is a task aggregator.
-    // Iterate over all the machines.
-    multimap<Cost_t, ResourceID_t> priority_res;
-    for (auto it = machine_to_rtnd_.begin();
-         it != machine_to_rtnd_.end();
-         ++it) {
-      Cost_t cost_to_res = EquivClassToResourceNode(ec, it->first);
-      ResourceID_t res_id =
-        ResourceIDFromString(it->second->resource_desc().uuid());
-      if (priority_res.size() < FLAGS_num_pref_arcs_agg_to_res) {
-        priority_res.insert(pair<Cost_t, ResourceID_t>(cost_to_res, res_id));
-      } else {
-        multimap<Cost_t, ResourceID_t>::reverse_iterator rit =
-          priority_res.rbegin();
-        if (cost_to_res < rit->first) {
-          priority_res.erase(priority_res.find(rit->first));
+    if (FLAGS_num_pref_arcs_agg_to_res > 0) {
+      // This branch implements the Xi(c_t, L_m, c_m) arcs of Whare-MCs.
+      // Iterate over all the machines and choose those to connect from the TEC.
+      multimap<Cost_t, ResourceID_t> priority_res;
+      for (auto it = machine_to_rtnd_.begin();
+           it != machine_to_rtnd_.end();
+           ++it) {
+        Cost_t cost_to_res = EquivClassToResourceNode(ec, it->first);
+        ResourceID_t res_id =
+          ResourceIDFromString(it->second->resource_desc().uuid());
+        if (priority_res.size() < FLAGS_num_pref_arcs_agg_to_res) {
+          // We haven't go enough priority machines yet, so add this one
           priority_res.insert(pair<Cost_t, ResourceID_t>(cost_to_res, res_id));
+        } else {
+          // If this is a better option than one of the high-priority machines
+          // we already have, swap it in.
+          multimap<Cost_t, ResourceID_t>::reverse_iterator rit =
+            priority_res.rbegin();
+          if (cost_to_res < rit->first) {
+            priority_res.erase(priority_res.find(rit->first));
+            priority_res.insert(pair<Cost_t, ResourceID_t>(
+                  cost_to_res, res_id));
+          }
         }
       }
-    }
-    for (multimap<Cost_t, ResourceID_t>::iterator it = priority_res.begin();
-         it != priority_res.end(); ++it) {
-      prefered_res->push_back(it->second);
+      for (multimap<Cost_t, ResourceID_t>::iterator it = priority_res.begin();
+           it != priority_res.end(); ++it) {
+        prefered_res->push_back(it->second);
+      }
     }
   } else if (machine_aggs_.find(ec) != machine_aggs_.end()) {
     // ec is a machine aggregator.

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -77,13 +77,19 @@ Cost_t WhareMapCostModel::UnscheduledAggToSinkCost(JobID_t job_id) {
 Cost_t WhareMapCostModel::TaskToClusterAggCost(TaskID_t task_id) {
   vector<EquivClass_t>* equiv_classes = GetTaskEquivClasses(task_id);
   CHECK_GT(equiv_classes->size(), 0);
-  // Avg runtime is in milliseconds, so we convert it to tenths of a second
-  uint64_t avg_pspi =
-    knowledge_base_->GetAvgPsPIForTEC(equiv_classes->front());
-  VLOG(1) << "Avg PsPI for TEC " << equiv_classes->front() << " is "
-          << avg_pspi;
+  uint64_t* worst_avg_pspi =
+    FindOrNull(worst_case_psi_map_, equiv_classes->front());
+  if (!worst_avg_pspi) {
+    // We don't have a current worst-case average PsPI value for this TEC, so
+    // we fall back to using the overall average for the TEC or zero.
+    // TODO(malte): check if this can ever return a non-zero value when we don't
+    // have a value in the worst_case_psi_map_.
+    return knowledge_base_->GetAvgPsPIForTEC(equiv_classes->front());
+  }
+  VLOG(1) << "Worst avg PsPI for TEC " << equiv_classes->front() << " is "
+          << *worst_avg_pspi;
   delete equiv_classes;
-  return avg_pspi;
+  return *worst_avg_pspi;
 }
 
 Cost_t WhareMapCostModel::TaskToResourceNodeCost(TaskID_t task_id,
@@ -410,6 +416,19 @@ void WhareMapCostModel::RecordECtoPsPIMapping(
     InsertIfNotPresent(&psi_map_, ec_pair, pspi_vec);
   }
   pspi_vec->push_back(pspi_value);
+  // Now check if this is a new worst-case; if so, record it
+  uint64_t new_avg_pspi = 0ULL;
+  for (auto it = pspi_vec->begin();
+       it != pspi_vec->end();
+       ++it) {
+    new_avg_pspi += *it;
+  }
+  new_avg_pspi /= pspi_vec->size();
+  uint64_t* cur_worst_avg_pspi =
+    FindOrNull(worst_case_psi_map_, ec_pair.first);
+  if (!cur_worst_avg_pspi || new_avg_pspi > *cur_worst_avg_pspi) {
+    InsertOrUpdate(&worst_case_psi_map_, ec_pair.first, new_avg_pspi);
+  }
   VLOG(1) << "Recording a psPi mapping: <" << ec_pair.first << ", "
           << ec_pair.second << "> -> " << pspi_value << ", now have "
           << pspi_vec->size() << " samples.";

--- a/src/scheduling/flow/wharemap_cost_model.cc
+++ b/src/scheduling/flow/wharemap_cost_model.cc
@@ -44,13 +44,22 @@ const TaskDescriptor& WhareMapCostModel::GetTask(TaskID_t task_id) {
 // The cost of leaving a task unscheduled should be higher than the cost of
 // scheduling it.
 Cost_t WhareMapCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
-  // TODO(ionel): Implement!
   const TaskDescriptor& td = GetTask(task_id);
   uint64_t now = GetCurrentTimestamp();
   uint64_t time_since_submit = now - td.submit_time();
   // timestamps are in microseconds, but we scale to tenths of a second here in
   // order to keep the costs small
-  return (time_since_submit / 100000);
+  uint64_t wait_time_centamillis = time_since_submit / 100000;
+  // Cost is the max of the average runtime and the wait time, so that the
+  // average runtime is a lower bound on the cost.
+  vector<EquivClass_t>* equiv_classes = GetTaskEquivClasses(task_id);
+  CHECK_GT(equiv_classes->size(), 0);
+  uint64_t avg_pspi =
+    knowledge_base_->GetAvgPsPIForTEC(equiv_classes->front());
+  VLOG(1) << "Avg PsPI for TEC " << equiv_classes->front() << " is "
+          << avg_pspi;
+  delete equiv_classes;
+  return max(WAIT_TIME_MULTIPLIER * wait_time_centamillis, avg_pspi + 1);
 }
 
 // The cost from the unscheduled to the sink is 0. Setting it to a value greater
@@ -58,6 +67,7 @@ Cost_t WhareMapCostModel::TaskToUnscheduledAggCost(TaskID_t task_id) {
 // of not running a task through the cost from the task to the unscheduled
 // aggregator.
 Cost_t WhareMapCostModel::UnscheduledAggToSinkCost(JobID_t job_id) {
+  // No cost in this cost model.
   return 0ULL;
 }
 
@@ -65,14 +75,15 @@ Cost_t WhareMapCostModel::UnscheduledAggToSinkCost(JobID_t job_id) {
 // task to run on any node in the cluster. The cost of the topology's arcs are
 // the same for all the tasks.
 Cost_t WhareMapCostModel::TaskToClusterAggCost(TaskID_t task_id) {
-  // TODO(ionel): Implement!
   vector<EquivClass_t>* equiv_classes = GetTaskEquivClasses(task_id);
   CHECK_GT(equiv_classes->size(), 0);
   // Avg runtime is in milliseconds, so we convert it to tenths of a second
-  uint64_t avg_runtime =
-    knowledge_base_->GetAvgRuntimeForTEC(equiv_classes->front());
+  uint64_t avg_pspi =
+    knowledge_base_->GetAvgPsPIForTEC(equiv_classes->front());
+  VLOG(1) << "Avg PsPI for TEC " << equiv_classes->front() << " is "
+          << avg_pspi;
   delete equiv_classes;
-  return (avg_runtime * 100);
+  return avg_pspi;
 }
 
 Cost_t WhareMapCostModel::TaskToResourceNodeCost(TaskID_t task_id,
@@ -108,7 +119,7 @@ Cost_t WhareMapCostModel::TaskToEquivClassAggregator(TaskID_t task_id,
                                                      EquivClass_t ec) {
   // The cost of scheduling via the cluster aggregator
   if (ec == cluster_aggregator_ec_)
-    return TaskToUnscheduledAggCost(task_id);
+    return TaskToClusterAggCost(task_id);
   else
     // XXX(malte): Implement other EC's costs!
     return 0;
@@ -131,11 +142,14 @@ vector<EquivClass_t>* WhareMapCostModel::GetTaskEquivClasses(
   vector<EquivClass_t>* equiv_classes = new vector<EquivClass_t>();
   TaskDescriptor* td_ptr = FindPtrOrNull(*task_map_, task_id);
   CHECK_NOTNULL(td_ptr);
-  // All tasks have an arc to the cluster aggregator.
-  equiv_classes->push_back(cluster_aggregator_ec_);
-  // We have one task agg per job. The id of the aggregator is the hash
-  // of the job id.
-  EquivClass_t task_agg = static_cast<EquivClass_t>(HashJobID(*td_ptr));
+  // We also have one task agg per job. The id of the aggregator is the
+  // hash of the job ID.
+  // This (first) EC will be used for the Whare-Map costs: the TEC
+  // aggregator is the source of the Whare-M cost arcs, and
+  // TaskToUnscheduledAggCost (currently) assumes that the first TEC is
+  // the one for which the cost model has statistics.
+  EquivClass_t task_agg =
+    static_cast<EquivClass_t>(HashString(td_ptr->binary()));
   equiv_classes->push_back(task_agg);
   task_aggs_.insert(task_agg);
   unordered_map<EquivClass_t, set<TaskID_t> >::iterator task_ec_it =
@@ -147,6 +161,8 @@ vector<EquivClass_t>* WhareMapCostModel::GetTaskEquivClasses(
     task_set.insert(task_id);
     CHECK(InsertIfNotPresent(&task_ec_to_set_task_id_, task_agg, task_set));
   }
+  // All tasks also have an arc to the cluster aggregator.
+  equiv_classes->push_back(cluster_aggregator_ec_);
   return equiv_classes;
 }
 
@@ -233,8 +249,13 @@ vector<TaskID_t>* WhareMapCostModel::GetIncomingEquivClassPrefArcs(
       // we should instead maintain a collection of tasks actually eligible for
       // scheduling.
       if (it->second->state() == TaskDescriptor::RUNNABLE ||
-          it->second->state() == TaskDescriptor::RUNNING)
+          it->second->state() == TaskDescriptor::RUNNING) {
+        VLOG(2) << "Adding arc from task " << it->first << " to EC " << tec
+                << "; task in state "
+                << ENUM_TO_STRING(TaskDescriptor::TaskState,
+                                  it->second->state());
         prefered_task->push_back(it->first);
+      }
     }
   } else if (task_aggs_.find(tec) != task_aggs_.end()) {
     // tec is a task aggregator.
@@ -244,9 +265,16 @@ vector<TaskID_t>* WhareMapCostModel::GetIncomingEquivClassPrefArcs(
     for (TaskMap_t::iterator it = task_map_->begin(); it != task_map_->end();
          ++it) {
       EquivClass_t task_agg =
-        static_cast<EquivClass_t>(HashJobID(*(it->second)));
+        static_cast<EquivClass_t>(HashString(it->second->binary()));
       if (task_agg == tec) {
-        prefered_task->push_back(it->first);
+        // XXX(malte): task_map_ contains ALL tasks ever seen by the system,
+        // including those that have completed, failed or are otherwise no
+        // longer present in the flow graph. We do some crude filtering here,
+        // but clearly we should instead maintain a collection of tasks actually
+        // eligible for scheduling.
+        if (it->second->state() == TaskDescriptor::RUNNABLE ||
+            it->second->state() == TaskDescriptor::RUNNING)
+          prefered_task->push_back(it->first);
       }
     }
   } else if (machine_aggs_.find(tec) != machine_aggs_.end()) {
@@ -351,16 +379,75 @@ void WhareMapCostModel::RemoveMachine(ResourceID_t res_id) {
 }
 
 void WhareMapCostModel::AddTask(TaskID_t task_id) {
+  // No-op in the WhareMap cost model
+}
+
+ResourceID_t WhareMapCostModel::MachineResIDForResource(ResourceID_t res_id) {
+  ResourceStatus* rs = FindPtrOrNull(*resource_map_, res_id);
+  CHECK_NOTNULL(rs);
+  ResourceTopologyNodeDescriptor* rtnd = rs->mutable_topology_node();
+  while (rtnd->resource_desc().type() != ResourceDescriptor::RESOURCE_MACHINE) {
+    CHECK(rtnd->has_parent_id()) << "Non-machine resource "
+      << rtnd->resource_desc().uuid() << " has no parent!";
+    rs = FindPtrOrNull(*resource_map_, ResourceIDFromString(rtnd->parent_id()));
+    rtnd = rs->mutable_topology_node();
+  }
+  return ResourceIDFromString(rtnd->resource_desc().uuid());
+}
+
+void WhareMapCostModel::RecordECtoPsPIMapping(
+    pair<EquivClass_t, EquivClass_t> ec_pair,
+    const TaskFinalReport& task_report) {
+  // Record the <task EC, machine EC> -> psPI mapping
+  vector<uint64_t>* pspi_vec = FindPtrOrNull(psi_map_, ec_pair);
+  VLOG(1) << "Runtime: " << task_report.runtime();
+  VLOG(1) << "Instructions: " << task_report.instructions();
+  uint64_t pspi_value =
+    (static_cast<uint64_t>(task_report.runtime()) * 10000000000) /
+    task_report.instructions();
+  if (!pspi_vec) {
+    pspi_vec = new vector<uint64_t>();
+    InsertIfNotPresent(&psi_map_, ec_pair, pspi_vec);
+  }
+  pspi_vec->push_back(pspi_value);
+  VLOG(1) << "Recording a psPi mapping: <" << ec_pair.first << ", "
+          << ec_pair.second << "> -> " << pspi_value << ", now have "
+          << pspi_vec->size() << " samples.";
 }
 
 void WhareMapCostModel::RemoveTask(TaskID_t task_id) {
   vector<EquivClass_t>* equiv_classes = GetTaskEquivClasses(task_id);
+  // Get the TD in order to find the resource
+  TaskDescriptor* td = FindPtrOrNull(*task_map_, task_id);
+  CHECK_NOTNULL(td);
+  // If the task has just successfully finished, we remember how it did.
+  // If the removal is a consequence of a failure or an abort, we don't
+  // record this, but still clear up the state below.
+  if (td->state() == TaskDescriptor::COMPLETED) {
+    CHECK_GT(equiv_classes->size(), 1);
+    // TODO(malte): We always use the first EC here; consider tracking
+    // data for all task ECs
+    EquivClass_t tec = equiv_classes->at(0);
+    // Get the machine EC that this task was previously running on
+    const TaskDescriptor& td = GetTask(task_id);
+    CHECK(td.has_scheduled_to_resource());
+    ResourceID_t res_id = ResourceIDFromString(td.scheduled_to_resource());
+    ResourceID_t machine_res_id = MachineResIDForResource(res_id);
+    EquivClass_t* mec = FindOrNull(machine_to_ec_, machine_res_id);
+    CHECK_NOTNULL(mec);
+    pair<EquivClass_t, EquivClass_t> ec_pair(tec, *mec);
+    CHECK(td.has_final_report());
+    RecordECtoPsPIMapping(ec_pair, td.final_report());
+  }
+  // Now remove the state we keep for this task
   for (vector<EquivClass_t>::iterator it = equiv_classes->begin();
        it != equiv_classes->end(); ++it) {
     unordered_map<EquivClass_t, set<TaskID_t> >::iterator set_it =
       task_ec_to_set_task_id_.find(*it);
     if (set_it != task_ec_to_set_task_id_.end()) {
+      // Remove the task's ID from the set of tasks in the EC
       set_it->second.erase(task_id);
+      // If the EC is now empty, remove it as well
       if (set_it->second.size() == 0) {
         task_ec_to_set_task_id_.erase(*it);
         task_aggs_.erase(*it);

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -100,6 +100,9 @@ class WhareMapCostModel : public CostModelInterface {
   // (Psi in the cost model description)
   unordered_map<pair<EquivClass_t, EquivClass_t>, vector<uint64_t>*,
     boost::hash<pair<EquivClass_t, EquivClass_t>>> psi_map_;
+  // Map to track task EC -> worst-machine EC PsPI;
+  // max_{c_m}(Psi(c_t, c_m))) in the cost model description
+  unordered_map<EquivClass_t, uint64_t> worst_case_psi_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -27,6 +27,8 @@ class WhareMapCostModel : public CostModelInterface {
   WhareMapCostModel(shared_ptr<ResourceMap_t> resource_map,
                     shared_ptr<TaskMap_t> task_map,
                     KnowledgeBase* kb);
+  // Debug info export
+  virtual const string DebugInfo() const;
   // Costs pertaining to leaving tasks unscheduled
   Cost_t TaskToUnscheduledAggCost(TaskID_t task_id);
   Cost_t UnscheduledAggToSinkCost(JobID_t job_id);
@@ -64,10 +66,13 @@ class WhareMapCostModel : public CostModelInterface {
  private:
   void AccumulateWhareMapStats(WhareMapStats* accumulator,
                                WhareMapStats* other);
+  Cost_t AverageFromVec(const vector<uint64_t>& vec) const;
   const TaskDescriptor& GetTask(TaskID_t task_id);
   void ComputeMachineTypeHash(const ResourceTopologyNodeDescriptor* rtnd_ptr,
                               size_t* hash);
   ResourceID_t MachineResIDForResource(ResourceID_t res_id);
+  Cost_t MaxFromVec(const vector<uint64_t>& vec) const;
+  Cost_t MinFromVec(const vector<uint64_t>& vec) const;
   // Cost to cluster aggregator EC
   Cost_t TaskToClusterAggCost(TaskID_t task_id);
 

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -54,10 +54,14 @@ class WhareMapCostModel : public CostModelInterface {
   vector<ResourceID_t>* GetTaskPreferenceArcs(TaskID_t task_id);
   pair<vector<EquivClass_t>*, vector<EquivClass_t>*>
     GetEquivClassToEquivClassesArcs(EquivClass_t tec);
+  uint64_t HashWhareMapStats(const WhareMapStats& wms);
   void AddMachine(ResourceTopologyNodeDescriptor* rtnd_ptr);
   void AddTask(TaskID_t task_id);
-  void RecordECtoPsPIMapping(pair<EquivClass_t, EquivClass_t> ec_pair,
-                             const TaskFinalReport& task_report);
+  void RecordMECtoPsPIMapping(pair<EquivClass_t, EquivClass_t> ec_pair,
+                              const TaskFinalReport& task_report);
+  void RecordMECAndCoRunnerSetToPsPIMapping(
+      pair<EquivClass_t, EquivClass_t> ec_pair,
+      const WhareMapStats& wms, const TaskFinalReport& task_report);
   void RemoveMachine(ResourceID_t res_id);
   void RemoveTask(TaskID_t task_id);
   FlowGraphNode* GatherStats(FlowGraphNode* accumulator, FlowGraphNode* other);
@@ -116,11 +120,21 @@ class WhareMapCostModel : public CostModelInterface {
   // (Psi in the cost model description)
   unordered_map<pair<EquivClass_t, EquivClass_t>, vector<uint64_t>*,
     boost::hash<pair<EquivClass_t, EquivClass_t>>> psi_map_;
+  // Map to track < <task EC, co-runner set>, machine EC> -> PsPI
+  // (Xi in the cost model description)
+  unordered_map<pair<pair<EquivClass_t, EquivClass_t>, EquivClass_t>,
+    vector<uint64_t>*,
+    boost::hash<pair<pair<EquivClass_t, EquivClass_t>, EquivClass_t>>> xi_map_;
   // Map to track task EC -> worst-machine EC PsPI;
   // max_{c_m}(Psi(c_t, c_m))) in the cost model description
   unordered_map<EquivClass_t, uint64_t> worst_case_psi_map_;
+  // Map to track task EC -> worst-environment EC PsPI;
+  // max_{c_m, L_m}(Xi(c_t, L_m, c_m))) in the cost model description
+  unordered_map<EquivClass_t, uint64_t> worst_case_xi_map_;
   // Map to track task EC -> best-machine EC PsPI
   unordered_map<EquivClass_t, uint64_t> best_case_psi_map_;
+  // Map to track task EC -> best-environment EC PsPI;
+  unordered_map<EquivClass_t, uint64_t> best_case_xi_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -54,6 +54,8 @@ class WhareMapCostModel : public CostModelInterface {
     GetEquivClassToEquivClassesArcs(EquivClass_t tec);
   void AddMachine(ResourceTopologyNodeDescriptor* rtnd_ptr);
   void AddTask(TaskID_t task_id);
+  void RecordECtoPsPIMapping(pair<EquivClass_t, EquivClass_t> ec_pair,
+                             const TaskFinalReport& task_report);
   void RemoveMachine(ResourceID_t res_id);
   void RemoveTask(TaskID_t task_id);
   FlowGraphNode* GatherStats(FlowGraphNode* accumulator, FlowGraphNode* other);
@@ -65,8 +67,11 @@ class WhareMapCostModel : public CostModelInterface {
   const TaskDescriptor& GetTask(TaskID_t task_id);
   void ComputeMachineTypeHash(const ResourceTopologyNodeDescriptor* rtnd_ptr,
                               size_t* hash);
+  ResourceID_t MachineResIDForResource(ResourceID_t res_id);
   // Cost to cluster aggregator EC
   Cost_t TaskToClusterAggCost(TaskID_t task_id);
+
+  const Cost_t WAIT_TIME_MULTIPLIER = 1;
 
   // Map of resources present in the system, initialised externally
   shared_ptr<ResourceMap_t> resource_map_;
@@ -75,7 +80,6 @@ class WhareMapCostModel : public CostModelInterface {
   // A knowledge base instance that we refer to for job runtime statistics,
   // initialised externally
   KnowledgeBase* knowledge_base_;
-
   // EC corresponding to the CLUSTER_AGG node
   EquivClass_t cluster_aggregator_ec_;
   // Mapping between machine equiv classes and machines.
@@ -92,6 +96,10 @@ class WhareMapCostModel : public CostModelInterface {
   unordered_set<EquivClass_t> task_aggs_;
   // Set of machine ECs
   unordered_set<EquivClass_t> machine_aggs_;
+  // Map to track <task EC, machine EC> -> PsPI
+  // (Psi in the cost model description)
+  unordered_map<pair<EquivClass_t, EquivClass_t>, vector<uint64_t>*,
+    boost::hash<pair<EquivClass_t, EquivClass_t>>> psi_map_;
 };
 
 }  // namespace firmament

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -80,6 +80,8 @@ class WhareMapCostModel : public CostModelInterface {
   const Cost_t WAIT_TIME_MULTIPLIER = 1LL;
   // Assumes we don't have more tha 48 cores for the moment ;-)
   const Cost_t COST_LOWER_BOUND = 48LL;
+  // Handy constant to help with the unit conversion
+  const uint64_t SECONDS_TO_PICOSECONDS = 1000000000000ULL;
 
   // Map of resources present in the system, initialised externally
   shared_ptr<ResourceMap_t> resource_map_;

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -78,8 +78,14 @@ class WhareMapCostModel : public CostModelInterface {
 
   // Static cost definitions
   const Cost_t WAIT_TIME_MULTIPLIER = 1LL;
-  // Assumes we don't have more tha 48 cores for the moment ;-)
-  const Cost_t COST_LOWER_BOUND = 48LL;
+  // This lower bound is required to compensate for the core-ID-based cost
+  // that we used to balance work across machines on a mostly-idle cluster.
+  // To avoid a priority inversion where a task remains unscheduled because only
+  // high core IDs are available and their cost exceeds the tasks's unscheduled
+  // cost, we add a lower bound of 2*MAX_CORE_ID to the unscheduled cost,
+  // ensuring that no path to the sink ever has less than MAX_CORE_ID cost.
+  // TODO(malte): Assumes we don't have more than 48 cores for the moment ;-)
+  const Cost_t COST_LOWER_BOUND = 96LL;
   // Handy constant to help with the unit conversion
   const uint64_t SECONDS_TO_PICOSECONDS = 1000000000000ULL;
 

--- a/src/scheduling/flow/wharemap_cost_model.h
+++ b/src/scheduling/flow/wharemap_cost_model.h
@@ -71,7 +71,10 @@ class WhareMapCostModel : public CostModelInterface {
   // Cost to cluster aggregator EC
   Cost_t TaskToClusterAggCost(TaskID_t task_id);
 
-  const Cost_t WAIT_TIME_MULTIPLIER = 1;
+  // Static cost definitions
+  const Cost_t WAIT_TIME_MULTIPLIER = 1LL;
+  // Assumes we don't have more tha 48 cores for the moment ;-)
+  const Cost_t COST_LOWER_BOUND = 48LL;
 
   // Map of resources present in the system, initialised externally
   shared_ptr<ResourceMap_t> resource_map_;

--- a/src/scheduling/knowledge_base.cc
+++ b/src/scheduling/knowledge_base.cc
@@ -11,6 +11,7 @@
 
 #include <sys/fcntl.h>
 
+#include "base/task_desc.pb.h"
 #include "misc/map-util.h"
 #include "misc/utils.h"
 
@@ -178,6 +179,20 @@ double KnowledgeBase::GetAvgIPMAForTEC(EquivClass_t id) {
        ++it) {
     accumulator += static_cast<double>(it->instructions()) /
       static_cast<double>(it->llc_refs());
+  }
+  return accumulator / res->size();
+}
+
+double KnowledgeBase::GetAvgPsPIForTEC(EquivClass_t id) {
+  const deque<TaskFinalReport>* res = FindOrNull(task_exec_reports_, id);
+  if (!res || res->size() == 0)
+    return 0;
+  double accumulator = 0;
+  for (deque<TaskFinalReport>::const_iterator it = res->begin();
+       it != res->end();
+       ++it) {
+    accumulator += static_cast<double>(it->runtime() * 10000000000.0) /
+      static_cast<double>(it->instructions());
   }
   return accumulator / res->size();
 }

--- a/src/scheduling/knowledge_base.cc
+++ b/src/scheduling/knowledge_base.cc
@@ -149,6 +149,11 @@ const deque<TaskFinalReport>* KnowledgeBase::GetFinalReportsForTEC(
   return res;
 }
 
+vector<EquivClass_t>* KnowledgeBase::GetResourceEquivClasses(
+    ResourceID_t resource_id) const {
+  return cost_model_->GetResourceEquivClasses(resource_id);
+}
+
 vector<EquivClass_t>* KnowledgeBase::GetTaskEquivClasses(
     TaskID_t task_id) const {
   return cost_model_->GetTaskEquivClasses(task_id);

--- a/src/scheduling/knowledge_base.cc
+++ b/src/scheduling/knowledge_base.cc
@@ -137,15 +137,15 @@ const deque<TaskPerfStatisticsSample>* KnowledgeBase::GetStatsForTask(
   return res;
 }
 
-const deque<TaskFinalReport>* KnowledgeBase::GetFinalStatsForTask(
+const deque<TaskFinalReport>* KnowledgeBase::GetFinalReportForTask(
       TaskID_t task_id) const {
-  vector<EquivClass_t>* equiv_classes =
-    cost_model_->GetTaskEquivClasses(task_id);
-  if (equiv_classes->size() == 0)
-    return NULL;
-  // TODO(ionel): This uses the first task equiv class for now.
-  const deque<TaskFinalReport>* res =
-    FindOrNull(task_exec_reports_, equiv_classes->front());
+  const deque<TaskFinalReport>* res = FindOrNull(task_exec_reports_, task_id);
+  return res;
+}
+
+const deque<TaskFinalReport>* KnowledgeBase::GetFinalReportsForTEC(
+      EquivClass_t ec_id) const {
+  const deque<TaskFinalReport>* res = FindOrNull(task_exec_reports_, ec_id);
   return res;
 }
 

--- a/src/scheduling/knowledge_base.h
+++ b/src/scheduling/knowledge_base.h
@@ -44,8 +44,10 @@ class KnowledgeBase {
       TaskID_t id) const;
   virtual double GetAvgCPIForTEC(EquivClass_t id);
   virtual double GetAvgIPMAForTEC(EquivClass_t id);
+  virtual double GetAvgPsPIForTEC(EquivClass_t id);
   virtual double GetAvgRuntimeForTEC(EquivClass_t id);
   const deque<TaskFinalReport>* GetFinalStatsForTask(TaskID_t task_id) const;
+  virtual double GetMaxPsPIForTEC(EquivClass_t id);
   vector<EquivClass_t>* GetTaskEquivClasses(TaskID_t task_id) const;
   void LoadKnowledgeBaseFromFile();
   void ProcessTaskFinalReport(const TaskFinalReport& report,

--- a/src/scheduling/knowledge_base.h
+++ b/src/scheduling/knowledge_base.h
@@ -46,8 +46,8 @@ class KnowledgeBase {
   virtual double GetAvgIPMAForTEC(EquivClass_t id);
   virtual double GetAvgPsPIForTEC(EquivClass_t id);
   virtual double GetAvgRuntimeForTEC(EquivClass_t id);
-  const deque<TaskFinalReport>* GetFinalStatsForTask(TaskID_t task_id) const;
-  virtual double GetMaxPsPIForTEC(EquivClass_t id);
+  const deque<TaskFinalReport>* GetFinalReportForTask(TaskID_t task_id) const;
+  const deque<TaskFinalReport>* GetFinalReportsForTEC(EquivClass_t ec_id) const;
   vector<EquivClass_t>* GetTaskEquivClasses(TaskID_t task_id) const;
   void LoadKnowledgeBaseFromFile();
   void ProcessTaskFinalReport(const TaskFinalReport& report,

--- a/src/scheduling/knowledge_base.h
+++ b/src/scheduling/knowledge_base.h
@@ -49,6 +49,7 @@ class KnowledgeBase {
   const deque<TaskFinalReport>* GetFinalReportForTask(TaskID_t task_id) const;
   const deque<TaskFinalReport>* GetFinalReportsForTEC(EquivClass_t ec_id) const;
   vector<EquivClass_t>* GetTaskEquivClasses(TaskID_t task_id) const;
+  vector<EquivClass_t>* GetResourceEquivClasses(ResourceID_t resource_id) const;
   void LoadKnowledgeBaseFromFile();
   void ProcessTaskFinalReport(const TaskFinalReport& report,
                               TaskID_t task_id);

--- a/src/webui/ec_details.tpl
+++ b/src/webui/ec_details.tpl
@@ -32,26 +32,6 @@ function median(values) {
     return (values[half-1] + values[half]) / 2.0;
 }
 
-function getRAM(data) {
-  rsize_ts = [];
-  for (i = 0; i < data.length; i++) {
-    rsize_ts.push(data[i].rsize / 1024.0 / 1024.0)
-  }
-}
-
-function getSchedStats(data) {
-  prev_run_ts = 0;
-  prev_wait_ts = 0;
-  sched_run_ts = [];
-  sched_wait_runnable_ts = [];
-  for (i = 0; i < data.length; i++) {
-    sched_run_ts.push(data[i].sched_run - prev_run_ts);
-    sched_wait_runnable_ts.push(data[i].sched_wait - prev_wait_ts);
-    prev_run_ts = data[i].sched_run;
-    prev_wait_ts = data[i].sched_wait;
-  }
-}
-
 function getReportStats(data) {
   runtime_series = [];
   cycles_series = [];
@@ -74,13 +54,11 @@ function getReportStats(data) {
 }
 
 function updateGraphs(data) {
-  getRAM(data['samples']);
-  getSchedStats(data['samples']);
   getReportStats(data['reports']);
 }
 
 function poll() {
-  url = "/stats/?task={{TASK_ID}}";
+  url = "/stats/?ec={{EC_ID}}";
   $.ajax({
     url: url,
     async: false,
@@ -101,10 +79,7 @@ function step() {
   $('#mai-box').sparkline(mai_series, {type: 'box', width: '100px'});
   $('#llc-ref-box').sparkline(llc_ref_series, {type: 'box', width: '100px'});
   $('#llc-miss-box').sparkline(llc_miss_series, {type: 'box', width: '100px'});
-  $('#rsize-ts').sparkline(rsize_ts, {tooltipSuffix: ' MB'});
-  $('#rsize-box').sparkline(rsize_ts, {type: 'box', width: '100px'});
   $('#sched_run-ts').sparkline(sched_run_ts, {tooltipSuffix: ' '});
-  $('#sched_wait_runnable-ts').sparkline(sched_wait_runnable_ts, {tooltipSuffix: ' '});
   // labels
   $('#runtime-text').text(" avg: " + mean(runtime_series) + ", median: " + median(runtime_series));
   $('#cycles-text').text(" avg: " + mean(cycles_series) + ", median: " + median(cycles_series));
@@ -134,104 +109,22 @@ $(function() {
 <!-- should be in header, but works here too -->
 <meta http-equiv="refresh" content="60" />
 
-<h1>Task {{TASK_ID}}</h1>
+<h1>Equivalence class {{EC_ID}}</h1>
 
 <table class="table table-bordered">
   <tr>
     <td>ID</td>
-    <td>{{TASK_ID}}</td>
+    <td>{{EC_ID}}</td>
   </tr>
   <tr>
-    <td>Name</td>
-    <td>{{TASK_NAME}}</td>
+    <td>Friendly name</td>
+    <td>{{EC_NAME}}</td>
   </tr>
-  <tr>
-    <td>Job</td>
-    <td><a href="/job/?id={{TASK_JOB_ID}}">{{TASK_JOB_ID}}</a> ({{TASK_JOB_NAME}})</td>
-  </tr>
-  <tr>
-    <td>Actions</td>
-    <td>
-      <a href="/task/?id={{TASK_ID}}&a=kill"><span class="glyphicon glyphicon-trash" aria-hidden="true" title="Terminate"></span></a>
-      <a href="http://{{TASK_LOCATION_HOST}}:{{WEBUI_PORT}}/collectl/graphs/?from={{TASK_START_TIME_HR}}-{{TASK_FINISH_TIME_HR}}"><span class="glyphicon glyphicon-stats" title="Stats"></span></a>
-    </td>
-  </tr>
-  <tr>
-    <td>Command</td>
-    <td><pre class="pre-x-scroll" style="width: 60%;">{{TASK_BINARY}} {{TASK_ARGS}}</pre></td>
-  </tr>
-  <tr>
-    <td>Equivalence classes</td>
-    <td>
-      <ul>
-        {{#TASK_TECS}}
-        <li><a href="/ec/?id={{TASK_TEC}}">{{TASK_TEC}}</a></li>
-        {{/TASK_TECS}}
-      </ul>
-    </td>
-  </tr>
-  <tr>
-    <td>Status</td>
-    <td>{{TASK_STATUS}}</td>
-  </tr>
-  <tr>
-    <td>Timestamps</td>
-    <td>
-       Submitted: <abbr class="timeago" title="{{TASK_SUBMIT_TIME}}">{{TASK_SUBMIT_TIME}}</abbr><br />
-       Scheduled: <abbr class="timeago" title="{{TASK_START_TIME}}">{{TASK_START_TIME}}</abbr><br />
-       Finished: <abbr class="timeago" title="{{TASK_FINISH_TIME}}">{{TASK_FINISH_TIME}}</abbr><br />
-    </td>
-  </tr>
-  <tr>
-    <td>Last heartbeat</td>
-    <td><abbr class="timeago" title="{{TASK_LAST_HEARTBEAT}}">{{TASK_LAST_HEARTBEAT}}</abbr></td>
-  </tr>
-  <tr>
-    <td>Location</td>
-    <td>
-       <a href="http://{{TASK_LOCATION_HOST}}:{{WEBUI_PORT}}/task/?id={{TASK_ID}}">{{TASK_LOCATION}}</a>
-       {{#TASK_DELEGATION}}
-       (delegated from <a href="http://{{TASK_DELEGATED_FROM_HOST}}:{{WEBUI_PORT}}/task/?id={{TASK_ID}}">{{TASK_DELEGATED_FROM_HOST}}</a>)
-       {{/TASK_DELEGATION}}
-    </td>
-  </tr>
-  <tr>
-    <td>Dependencies</td>
-    <td>
-      <ol>
-        {{#TASK_DEPS}}
-        <li><a href="/ref/?id={{TASK_DEP_ID}}">{{TASK_DEP_ID}}</a></li>
-        {{/TASK_DEPS}}
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>Spawned</td>
-    <td>
-      <ol>
-        {{#TASK_SPAWNED}}
-        <li><a href="/task/?id={{TASK_SPAWNED_ID}}">{{TASK_SPAWNED_ID}}</a></li>
-        {{/TASK_SPAWNED}}
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>Outputs</td>
-    <td>
-      <ol>
-      {{#TASK_OUTPUTS}}
-        <li><a href="/ref/?id={{TASK_OUTPUT_ID}}">{{TASK_OUTPUT_ID}}</a></li>
-      {{/TASK_OUTPUTS}}
-      </ol>
-    </td>
-  </tr>
-  <tr>
-    <td>Logs</td>
-    <td>
-      <a href="http://{{TASK_LOCATION_HOST}}:{{WEBUI_PORT}}/tasklog/?id={{TASK_ID}}&a=1">stdout</a> &ndash;
-      <a href="http://{{TASK_LOCATION_HOST}}:{{WEBUI_PORT}}/tasklog/?id={{TASK_ID}}&a=2">stderr</a>
-    </td>
-  </tr>
+</table>
+
+<h2>Statistics</h2>
+
+<table class="table table-bordered">
   <tr>
     <td>Runtime</td>
     <td><span id="runtime-box">Waiting for data...</span> <span id="runtime-text" /></td>

--- a/src/webui/flow_graph.tpl
+++ b/src/webui/flow_graph.tpl
@@ -1,0 +1,59 @@
+{{>HEADER}}
+
+{{>PAGE_HEADER}}
+
+<style type="text/css">
+  #flow-graph {
+    width: 100%;
+    min-height: 90%;
+    border: 1px solid lightgray;
+  }
+</style>
+
+<h1>Current flow graph</h1>
+
+<div id="flow-graph"></div>
+
+<script type="text/javascript">
+// create an array with nodes
+var nodes;
+// create an array with edges
+var edges;
+
+$(function() {
+  url = "/sched/flowgraph/?json=1";
+  $.ajax({
+    url: url,
+    async: false,
+    dataType: 'json',
+    success: function(data) {
+      nodes = new vis.DataSet(data.nodes);
+      edges = new vis.DataSet(data.edges);
+      plotNetwork();
+    },
+    error: function(req, err, et) {
+      window.alert(et);
+    }});
+});
+
+function plotNetwork() {
+  // create a network
+  var container = document.getElementById('flow-graph');
+  var data = {
+    nodes: nodes,
+    edges: edges
+  };
+  var options = {
+    layout: {
+    }, 
+    edges: {
+      smooth: true,
+      arrows: {to : true }
+    }
+  };
+  var network = new vis.Network(container, data, options);
+}
+</script>
+
+
+{{>PAGE_FOOTER}}

--- a/src/webui/header.tpl
+++ b/src/webui/header.tpl
@@ -78,6 +78,13 @@
   <!-- Friendly timestamps -->
   <script src="https://cdn.rawgit.com/rmm5t/jquery-timeago/master/jquery.timeago.js"></script>
 
+  <!-- Flow graph visualisation -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.3.0/vis.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.3.0/vis.min.css">
+
+  <!-- d3 for visualisation -->
+  <script src="http://d3js.org/d3.v3.min.js"></script>
+
   <!-- Workaround for JQS + bootstrap issue -->
   <style>
     .jqstooltip {

--- a/src/webui/main.tpl
+++ b/src/webui/main.tpl
@@ -34,6 +34,8 @@
 <h2>Scheduler</h2>
 
 <p><b>Active scheduler:</b> {{SCHEDULER_NAME}}
+{{#FLOW_SCHEDULER_DETAILS}}
+<p><b>Cost model:</b> {{FLOW_SCHEDULER_COST_MODEL}}
 
 <ol>
 {{#SCHEDULER_ITER}}
@@ -42,5 +44,6 @@
                                                           <a href="/sched/?iter={{SCHEDULER_ITER_ID}}&a=png">PNG</a>)</li>
 {{/SCHEDULER_ITER}}
 </ol>
+{{/FLOW_SCHEDULER_DETAILS}}
 
 {{>PAGE_FOOTER}}

--- a/src/webui/main.tpl
+++ b/src/webui/main.tpl
@@ -36,8 +36,9 @@
 <p><b>Active scheduler:</b> {{SCHEDULER_NAME}}
 {{#FLOW_SCHEDULER_DETAILS}}
 <p><b>Cost model:</b> {{FLOW_SCHEDULER_COST_MODEL}}
-
+<p><b>Flow graph:</b>
 <ol>
+  <li><a href="/sched/flowgraph/"><b>Current</b></a>
 {{#SCHEDULER_ITER}}
   <li>Iteration {{SCHEDULER_ITER_ID}} &ndash; flow graph (<a href="/sched/?iter={{SCHEDULER_ITER_ID}}&a=dimacs">DIMACS</a>;
                                                           <a href="/sched/?iter={{SCHEDULER_ITER_ID}}&a=gv">GV</a>;

--- a/src/webui/resource_status.tpl
+++ b/src/webui/resource_status.tpl
@@ -90,8 +90,14 @@ $(function() {
     <td>{{RES_FRIENDLY_NAME}}</td>
   </tr>
   <tr>
-    <td>Equiv class</td>
-    <td>{{RES_REC}}</td>
+    <td>Equivalence class</td>
+    <td>
+      <ul>
+        {{#RES_RECS}}
+        <li><a href="/ec/?id={{RES_REC}}">{{RES_REC}}</a></li>
+        {{/RES_RECS}}
+      </ul>
+    </td>
   </tr>
   <tr>
     <td>Type</td>

--- a/src/webui/resources_list.tpl
+++ b/src/webui/resources_list.tpl
@@ -33,7 +33,6 @@
 
 <h2>Topology</h2>
 
-<script src="http://d3js.org/d3.v3.min.js"></script>
 <script>
 
 var width = screen.availWidth,

--- a/src/webui/task_status.tpl
+++ b/src/webui/task_status.tpl
@@ -187,6 +187,12 @@ $(function() {
     <td><abbr class="timeago" title="{{TASK_LAST_HEARTBEAT}}">{{TASK_LAST_HEARTBEAT}}</abbr></td>
   </tr>
   <tr>
+    <td>Scheduled to</td>
+    <td>
+       <a href="/resource/?id={{TASK_SCHEDULED_TO}}">{{TASK_SCHEDULED_TO}}</a>
+    </td>
+  </tr>
+  <tr>
     <td>Location</td>
     <td>
        <a href="http://{{TASK_LOCATION_HOST}}:{{WEBUI_PORT}}/task/?id={{TASK_ID}}">{{TASK_LOCATION}}</a>


### PR DESCRIPTION
This PR brings the complete implementation of the Whare-Map cost model into the master branch.

This cost model is based on an [ISCA 2013 paper](http://dl.acm.org/citation.cfm?id=2485975) and uses instructions-per-second (IPS) as an indirect metric for both machine type affinity and co-location interference. The cost model transforms the Whare-Map approach into a flow scheduling cost model, and as a side effect improves its effectiveness: the original approach used a stochastic hill climbing approach and was not guaranteed to pick the best option, while the flow scheduler cost model always does.

The implementation supports both the Whare-M (co-location-agnostic) and Whare-MCs (co-location-aware) approaches; Whare-MCs is enabled and controlled using the `--num_pref_arcs_agg_to_res` command line flag.

In experiments, this cost model improves the runtime of synthetic test workloads by 2-4x in the median as it avoids interference and matches tasks to the most appropriate machine.